### PR TITLE
introduce a common overlay script for all operators

### DIFF
--- a/.github/workflows/make-test-overlay.yaml
+++ b/.github/workflows/make-test-overlay.yaml
@@ -1,0 +1,16 @@
+---
+name: Test Overlay CI
+
+"on":
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run make test-overlay
+        run: make test-overlay

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,107 @@ shellcheck: venv
 bashate: venv
 	cd $(TELCO5G_KONFLUX_DIR) && $(TELCO5G_KONFLUX_BIN)/bashate --ignore=E006 $(shell find $(TELCO5G_KONFLUX_DIR) -path $(TELCO5G_KONFLUX_VENV) -prune -o -type f -name "*.sh" -print)
 
+# Helper function to run a specific test for a given operator and release.
+define run-overlay-test-for-release
+	cd $(TELCO5G_KONFLUX_DIR)/test/overlay && \
+	debug_flag=""; \
+	if [[ -n "$(DEBUG)" ]]; then \
+		debug_flag="--debug"; \
+	fi; \
+	if [[ -n "$(TEST)" ]]; then \
+		test_file="$(1)/$(2)/$(TEST)"; \
+		if [[ -f "$$test_file" ]]; then \
+			echo "Running specific test: $(TEST) for $(1) release: $(2)"; \
+			if ! "$$test_file" $$debug_flag; then \
+				exit 1; \
+			fi; \
+		else \
+			echo "Error: Test file $$test_file not found"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "Testing $(1) release: $(2)"; \
+		./runner.sh "$(1)" "$(2)" $$debug_flag; \
+	fi
+endef
+
+# Generic function to run tests for any operator and release 
+# - The RELEASE variable (optional) is used to run tests for a specific release. If not set, all releases
+#   for the operator are tested. 
+# - The TEST variable (optional) is used to run a specific test file. If not set, all tests are run.
+# - The DEBUG variable (optional) is used to enable verbose/debug output in the test scripts for easier troubleshooting.
+define run-overlay-tests
+	@echo "Running tests for $(1) operator..."
+	@cd $(TELCO5G_KONFLUX_DIR)/test/overlay && \
+	if [[ -n "$(RELEASE)" ]]; then \
+		release_dir="$(1)/$(RELEASE)"; \
+		if [[ -d "$$release_dir" ]]; then \
+			$(call run-overlay-test-for-release,$(1),$(RELEASE)) \
+		else \
+			echo "Error: Release directory $$release_dir not found"; \
+			exit 1; \
+		fi; \
+	else \
+		if [[ -n "$(TEST)" ]]; then \
+			echo "Running specific test $(TEST) for all releases of $(1)"; \
+			test_found=false; \
+			for release_dir in $(1)/4.*; do \
+				if [[ -d "$$release_dir" ]]; then \
+					release=$$(basename "$$release_dir"); \
+					test_file="$$release_dir/$(TEST)"; \
+					if [[ -f "$$test_file" ]]; then \
+						test_found=true; \
+						$(call run-overlay-test-for-release,$(1),$$release) \
+					else \
+						echo "Warning: Test file $(TEST) not found for release $$release"; \
+					fi; \
+				fi; \
+			done; \
+			if [[ "$$test_found" == "false" ]]; then \
+				echo "Error: Test file $(TEST) not found in any release for operator $(1)"; \
+				exit 1; \
+			fi; \
+		else \
+			for release_dir in $(1)/4.*; do \
+				if [[ -d "$$release_dir" ]]; then \
+					release=$$(basename "$$release_dir"); \
+					$(call run-overlay-test-for-release,$(1),$$release) \
+				fi; \
+			done; \
+		fi; \
+	fi
+endef
+
+# Test target for all operators
+.PHONY: test-overlay
+test-overlay: test-overlay-lca test-overlay-nrop test-overlay-ocloud test-overlay-talm ## Run all operator tests (use RELEASE=x.y for specific release, DEBUG=1 for verbose output)
+	@echo "All operator tests completed."
+
+# Test targets for individual operators
+# Usage examples:
+#   make test-overlay-<operator>                                      # Run all releases for operator 
+#   make test-overlay-<operator> RELEASE=4.20                         # Run specific release for operator
+#   make test-overlay-<operator> DEBUG=1                              # Run all releases for operator with verbose output
+#   make test-overlay-<operator> RELEASE=4.20 DEBUG=1                 # Run specific release for operator with verbose output
+#   make test-overlay-<operator> TEST=00.test.sh                      # Run a specific test file for all releases of operator
+#   make test-overlay-<operator> TEST=00.test.sh RELEASE=4.20         # Run a specific test file for a specific release
+#   make test-overlay-<operator> TEST=00.test.sh RELEASE=4.20 DEBUG=1 # Run a specific test file for a specific release with verbose output
+.PHONY: test-overlay-lca
+test-overlay-lca: ## Run tests for LCA operator (use RELEASE=x.y for specific release, DEBUG=1 for verbose output)
+	$(call run-overlay-tests,lca)
+
+.PHONY: test-overlay-nrop
+test-overlay-nrop: ## Run tests for NROP operator (use RELEASE=x.y for specific release, DEBUG=1 for verbose output)
+	$(call run-overlay-tests,nrop)
+
+.PHONY: test-overlay-ocloud
+test-overlay-ocloud: ## Run tests for OCLOUD operator (use RELEASE=x.y for specific release, DEBUG=1 for verbose output)
+	$(call run-overlay-tests,ocloud)
+
+.PHONY: test-overlay-talm
+test-overlay-talm: ## Run tests for TALM operator (use RELEASE=x.y for specific release, DEBUG=1 for verbose output)
+	$(call run-overlay-tests,talm)
+
 # The 'clean' target removes generated artifacts like the virtual environment,
 # the 'bin' directory for downloaded tools, and Python cache files.
 .PHONY: clean

--- a/scripts/bundle/konflux-bundle-overlay.sh
+++ b/scripts/bundle/konflux-bundle-overlay.sh
@@ -442,16 +442,9 @@ SYNOPSIS
 
 EXAMPLES
 
-   - Pin (sha256) images on 'oran-o2ims.clusterserviceversion.yaml' according to the configuration on 'pin_images.in.yaml':
-
-     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-csv-file oran-o2ims.clusterserviceversion.yaml
-
-   - Pin (sha256) images on 'oran-o2ims.clusterserviceversion.yaml' according to the configuration on 'pin_images.in.yaml'
-     and map them to the production registry according to the configuration on 'map_images.in.yaml':
-
-     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-mapping-file map_images.in.yaml --set-mapping-production --set-csv-file oran-o2ims.clusterserviceversion.yaml
-
-   - Ditto above and overlay the release according to the configuration on 'release.in.yaml':
+   - Pin (sha256) images on 'oran-o2ims.clusterserviceversion.yaml' as per the configuration on 'pin_images.in.yaml',
+     map them to the production registry according to the configuration on 'map_images.in.yaml' and overlay the release
+     according to the configuration on 'release.in.yaml':
 
      $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-mapping-file map_images.in.yaml --set-mapping-production --set-release-file release.in.yaml --set-csv-file oran-o2ims.clusterserviceversion.yaml
 

--- a/scripts/bundle/konflux-bundle-overlay.sh
+++ b/scripts/bundle/konflux-bundle-overlay.sh
@@ -4,71 +4,89 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-#set -x
+# set -x
 # Debug mode off by default
 DEBUG=false
 
-SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 SCRIPT_NAME=$(basename "$(readlink -f "${BASH_SOURCE[0]}")")
 
 MAP_STAGING="staging"
 MAP_PRODUCTION="production"
 MANAGER_KEY="manager"
 
-debug() {
+# release yaml variables allowed
+declare -A RELEASE_VARIABLES_ALLOWED=(
+    ["annotations"]=true
+    ["alm_examples"]=true
+    ["containerImage"]=true
+    ["description"]=true
+    ["display_name"]=true
+    ["manager_version"]=true
+    ["min_kube_version"]=true
+    ["recert_image"]=true
+    ["subscription_badges"]=true
+    ["version"]=true
+)
+
+print_log() {
+    echo "[$SCRIPT_NAME] $1"
+}
+
+print_log_debug() {
     if [ "$DEBUG" = true ]; then
-    echo "[DEBUG] $1"
+        print_log "[DEBUG] $1"
     fi
 }
 
 check_preconditions() {
-    echo "Checking pre-conditions..."
+    print_log "Checking pre-conditions..."
 
     # yq must be installed
-    command -v yq >/dev/null 2>&1 || { echo "Error: yq seems not to be installed." >&2; exit 1; }
-    echo "Checking pre-conditions completed!"
+    command -v yq >/dev/null 2>&1 || { print_log "Error: yq seems not to be installed." >&2; exit 1; }
+    print_log "Checking pre-conditions completed!"
     return 0
 }
 
 pin_images() {
-    echo "Pinning images (sha256)..."
+    print_log "Pinning images (sha256)..."
 
     for image_name in "${!IMAGE_TO_SOURCE[@]}"; do
-    echo "Replacing: image_name: $image_name, source: ${IMAGE_TO_SOURCE[$image_name]}, target: ${IMAGE_TO_TARGET[$image_name]}"
-    sed -i "s,${IMAGE_TO_SOURCE[$image_name]},${IMAGE_TO_TARGET[$image_name]},g" $ARG_CSV_FILE
+        print_log "Replacing: image_name: $image_name, source: ${IMAGE_TO_SOURCE[$image_name]}, target: ${IMAGE_TO_TARGET[$image_name]}"
+        sed -i "s,${IMAGE_TO_SOURCE[$image_name]},${IMAGE_TO_TARGET[$image_name]},g" "$ARG_CSV_FILE"
     done
 
-    echo "Pinning images completed!"
+    print_log "Pinning images completed!"
     return 0
 }
 
 add_related_images() {
-    echo "Adding related images..."
+    print_log "Adding related images..."
 
     # remove the existing section
-    echo "Removing .spec.relatedImages"
-    yq e -i 'del(.spec.relatedImages)' $ARG_CSV_FILE
+    print_log "Removing .spec.relatedImages"
+    yq e -i 'del(.spec.relatedImages)' "$ARG_CSV_FILE"
 
     # create a new section from scratch
     declare -i index=0
     for image_name in "${!IMAGE_TO_SOURCE[@]}"; do
-    echo "Adding related image: name: $image_name source: ${IMAGE_TO_SOURCE[$image_name]}, image: ${IMAGE_TO_TARGET[$image_name]}"
-    yq e -i ".spec.relatedImages[$index].name=\"$image_name\" |
-                .spec.relatedImages[$index].image=\"${IMAGE_TO_TARGET[$image_name]}\"" $ARG_CSV_FILE
-    index=$index+1
+        print_log "Adding related image: name: $image_name source: ${IMAGE_TO_SOURCE[$image_name]}, image: ${IMAGE_TO_TARGET[$image_name]}"
+        yq e -i ".spec.relatedImages[$index].name=\"$image_name\" |
+                .spec.relatedImages[$index].image=\"${IMAGE_TO_TARGET[$image_name]}\"" "$ARG_CSV_FILE"
+        index=$((index + 1))
     done
 
-    echo "Adding related images completed!"
+    print_log "Adding related images completed!"
     return 0
 }
 
 parse_mapping_images_file() {
-    echo "Parsing mapping image file..."
+    print_log "Parsing mapping image file..."
 
-    # Extract keys and images
-    local keys=($(yq eval '.[].key' "$ARG_MAPPING_FILE"))
-    local staging_images=($(yq eval '.[].staging' "$ARG_MAPPING_FILE"))
-    local production_images=($(yq eval '.[].production' "$ARG_MAPPING_FILE"))
+    # Extract keys and images using mapfile/readarray for better shellcheck compliance
+    local keys staging_images production_images
+    mapfile -t keys < <(yq eval '.[].key' "$ARG_MAPPING_FILE")
+    mapfile -t staging_images < <(yq eval '.[].staging' "$ARG_MAPPING_FILE")
+    mapfile -t production_images < <(yq eval '.[].production' "$ARG_MAPPING_FILE")
     local entries=${#keys[@]}
 
     # Declare associative arrays
@@ -77,71 +95,72 @@ parse_mapping_images_file() {
 
     declare -i i=0
     for ((; i<entries; i++)); do
-    # Store in associative arrays
-    local key=${keys[i]}
-    IMAGE_TO_STAGING["$key"]="${staging_images[i]}"
-    IMAGE_TO_PRODUCTION["$key"]="${production_images[i]}"
+        # Store in associative arrays
+        local key=${keys[i]}
+        IMAGE_TO_STAGING["$key"]="${staging_images[i]}"
+        IMAGE_TO_PRODUCTION["$key"]="${production_images[i]}"
     done
 
-    echo "Parsing mapping image file completed!"
+    print_log "Parsing mapping image file completed!"
     return 0
 }
 
 map_images() {
 
     if [[ ! -f "$ARG_MAPPING_FILE" ]]; then
-    echo "Skipping images mapping!"
-    return 0
+        print_log "Skipping images mapping!"
+        return 0
     fi
 
-    echo "Mapping images ..."
+    print_log "Mapping images ..."
 
     parse_mapping_images_file
 
     for image_name in "${!IMAGE_TO_TARGET[@]}"; do
-    local image_name_target="${IMAGE_TO_TARGET[$image_name]}"
+        local image_name_target="${IMAGE_TO_TARGET[$image_name]}"
 
-    # requires an image already pinned, sha256 format: '...@sha256:..."
-    local image_name_target_trimmed="${image_name_target%@*}"
+        # requires an image already pinned, sha256 format: '...@sha256:..."
+        local image_name_target_trimmed="${image_name_target%@*}"
 
-    local image_name_target_trimmed_mapped=""
-    if [[ "$ARG_MAP" == "$MAP_STAGING" ]]; then
-        if [[ -z "${IMAGE_TO_STAGING[$image_name]-}" ]]; then
-            echo "Warning: no staging image mapped for: $image_name" >&2
-            continue
+        local image_name_target_trimmed_mapped=""
+        if [[ "$ARG_MAP" == "$MAP_STAGING" ]]; then
+            if [[ -z "${IMAGE_TO_STAGING[$image_name]-}" ]]; then
+                print_log "Warning: no staging image mapped for: $image_name" >&2
+                continue
+            fi
+
+            image_name_target_trimmed_mapped="${IMAGE_TO_STAGING[$image_name]}"
+
+        elif [[ "$ARG_MAP" == "$MAP_PRODUCTION" ]]; then
+            if [[ -z "${IMAGE_TO_PRODUCTION[$image_name]-}" ]]; then
+                print_log "Warning: no production image mapped for: $image_name" >&2
+                continue
+            fi
+
+            image_name_target_trimmed_mapped="${IMAGE_TO_PRODUCTION[$image_name]}"
+
         fi
 
-        image_name_target_trimmed_mapped="${IMAGE_TO_STAGING[$image_name]}"
-
-    elif [[ "$ARG_MAP" == "$MAP_PRODUCTION" ]]; then
-        if [[ -z "${IMAGE_TO_PRODUCTION[$image_name]-}" ]]; then
-            echo "Warning: no production image mapped for: $image_name" >&2
-            continue
-        fi
-
-        image_name_target_trimmed_mapped="${IMAGE_TO_PRODUCTION[$image_name]}"
-
-    fi
-
-    echo "Replacing: image_name: $image_name, original: $image_name_target_trimmed, mapped: $image_name_target_trimmed_mapped"
-    sed -i "s,$image_name_target_trimmed,$image_name_target_trimmed_mapped,g" $ARG_CSV_FILE
+        print_log "Replacing: image_name: $image_name, original: $image_name_target_trimmed, mapped: $image_name_target_trimmed_mapped"
+        sed -i "s,$image_name_target_trimmed,$image_name_target_trimmed_mapped,g" "$ARG_CSV_FILE"
     done
 
-    echo "Mapping images completed"
+    print_log "Mapping images completed!"
 }
 
 parse_pinning_images_file() {
-    echo "Parsing pinning file..."
+    print_log "Parsing pinning file..."
 
     if [[ ! -f "$ARG_PINNING_FILE" ]]; then
-    echo "Error: File '$ARG_PINNING_FILE' not found. " >&2
-    exit 1
+        print_log "Error: File '$ARG_PINNING_FILE' not found. " >&2
+        exit 1
     fi
 
-    # Extract keys and images
-    local keys=($(yq eval '.[].key' "$ARG_PINNING_FILE"))
-    local sources=($(yq eval '.[].source' "$ARG_PINNING_FILE"))
-    local targets=($(yq eval '.[].target' "$ARG_PINNING_FILE"))
+    # Extract keys and images using mapfile/readarray for better shellcheck compliance
+    local keys sources targets
+    mapfile -t keys < <(yq eval '.[].key' "$ARG_PINNING_FILE")
+    mapfile -t sources < <(yq eval '.[].source' "$ARG_PINNING_FILE")
+    mapfile -t targets < <(yq eval '.[].target' "$ARG_PINNING_FILE")
     local entries=${#keys[@]}
 
     # Declare associative arrays
@@ -150,30 +169,30 @@ parse_pinning_images_file() {
 
     declare -i i=0
     for ((; i<entries; i++)); do
-    # Store in associative arrays
-    local key=${keys[i]}
-    IMAGE_TO_SOURCE["$key"]="${sources[i]}"
-    IMAGE_TO_TARGET["$key"]="${targets[i]}"
+        # Store in associative arrays
+        local key=${keys[i]}
+        IMAGE_TO_SOURCE["$key"]="${sources[i]}"
+        IMAGE_TO_TARGET["$key"]="${targets[i]}"
     done
 
     if [ "$DEBUG" = true ]; then
-    for key in "${!IMAGE_TO_SOURCE[@]}"; do
-        echo "- key: $key"
-        echo "  source: ${IMAGE_TO_SOURCE[$name]}"
-        echo "  target: ${IMAGE_TO_TARGET[$name]}"
-    done
+        for key in "${!IMAGE_TO_SOURCE[@]}"; do
+            print_log "- key: $key"
+            print_log "  source: ${IMAGE_TO_SOURCE[$key]}"
+            print_log "  target: ${IMAGE_TO_TARGET[$key]}"
+        done
     fi
 
-    echo "Parsing pinning file completed!"
+    print_log "Parsing pinning file completed!"
     return 0
 }
 
 parse_args() {
-    echo "Parsing args..."
+    print_log "Parsing args..."
 
     # command line options
     local options=
-    local long_options="set-pinning-file:,set-mapping-file:,set-csv-file:,set-mapping-staging,set-mapping-production,help"
+    local long_options="set-pinning-file:,set-mapping-file:,set-release-file:,set-csv-file:,set-mapping-staging,set-mapping-production,help"
 
     local parsed
     parsed=$(getopt --options="$options" --longoptions="$long_options" --name "$SCRIPT_NAME" -- "$@")
@@ -185,125 +204,220 @@ parse_args() {
     declare -g ARG_PINNING_FILE=""
     declare -g ARG_CSV_FILE=""
     declare -g ARG_MAP=""
+    declare -g ARG_RELEASE_FILE=""
+
     while true; do
-    case $1 in
-        --help)
-            usage
-            exit
-            ;;
-        --set-csv-file)
-            ARG_CSV_FILE=$2
-            shift 2
-            ;;
-        --set-pinning-file)
-            ARG_PINNING_FILE=$2
-            shift 2
-            ;;
-        --set-mapping-file)
-            ARG_MAPPING_FILE=$2
-            shift 2
-            ;;
-        --set-mapping-staging)
-            map_staging=1
-            ARG_MAP=$MAP_STAGING
-            shift 1
-            ;;
-        --set-mapping-production)
-            map_production=1
-            ARG_MAP=$MAP_PRODUCTION
-            shift 1
-            ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            echo "Error: unexpected option: $1" >&2
-            usage
-            exit 1
-            ;;
-    esac
+        case $1 in
+            --help)
+                usage
+                exit 0
+                ;;
+            --set-csv-file)
+                ARG_CSV_FILE=$2
+                shift 2
+                ;;
+            --set-pinning-file)
+                ARG_PINNING_FILE=$2
+                shift 2
+                ;;
+            --set-mapping-file)
+                ARG_MAPPING_FILE=$2
+                shift 2
+                ;;
+            --set-mapping-staging)
+                map_staging=1
+                ARG_MAP=$MAP_STAGING
+                shift 1
+                ;;
+            --set-mapping-production)
+                map_production=1
+                ARG_MAP=$MAP_PRODUCTION
+                shift 1
+                ;;
+            --set-release-file)
+                ARG_RELEASE_FILE=$2
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                print_log "Error: unexpected option: $1" >&2
+                usage
+                exit 1
+                ;;
+        esac
     done
 
     # validate images file
-    if [[ -n $ARG_PINNING_FILE && ! -f "$ARG_PINNING_FILE" ]]; then
-    echo "Error: file '$ARG_PINNING_FILE' does not exist." >&2
-    exit 1
+    if [[ -n "$ARG_PINNING_FILE" && ! -f "$ARG_PINNING_FILE" ]]; then
+        print_log "Error: file '$ARG_PINNING_FILE' does not exist." >&2
+        exit 1
+    fi
+
+    # validate release file
+    if [[ -n "$ARG_RELEASE_FILE" && ! -f "$ARG_RELEASE_FILE" ]]; then
+        print_log "Error: file '$ARG_RELEASE_FILE' does not exist." >&2
+        exit 1
     fi
 
     # validate csv file
-    if [[ -n $ARG_CSV_FILE && ! -f "$ARG_CSV_FILE" ]]; then
-    echo "Error: file '$ARG_CSV_FILE' does not exist." >&2
-    exit 1
+    if [[ -n "$ARG_CSV_FILE" && ! -f "$ARG_CSV_FILE" ]]; then
+        print_log "Error: file '$ARG_CSV_FILE' does not exist." >&2
+        exit 1
     fi
 
     # validate map options
     if [[ $map_staging -eq 1 && $map_production -eq 1 ]]; then
-    echo "Error: cannot specify both '--set-mapping-staging' and '--set-mapping-production'." >&2
-    exit 1
+        print_log "Error: cannot specify both '--set-mapping-staging' and '--set-mapping-production'." >&2
+        exit 1
     fi
 
     if [[ $map_staging -eq 1 || $map_production -eq 1 ]]; then
-    if [[ ! -n $ARG_MAPPING_FILE ]]; then
-        echo "Error: specify '--set-mapping-file' to use a container registry map file." >&2
-        exit 1
+        if [[ -z "$ARG_MAPPING_FILE" ]]; then
+            print_log "Error: specify '--set-mapping-file' to use a container registry map file." >&2
+            exit 1
+        fi
+
+        if [[ ! -f "$ARG_MAPPING_FILE" ]]; then
+            print_log "Error: file '$ARG_MAPPING_FILE' does not exist." >&2
+            exit 1
+        fi
     fi
 
-    if [[ ! -f "$ARG_MAPPING_FILE" ]]; then
-        echo "Error: file '$ARG_MAPPING_FILE' does not exist." >&2
-        exit 1
-    fi
-    fi
-
-    if [[ -n $ARG_MAPPING_FILE ]]; then
-    if [[ $map_staging -eq 0 && $map_production -eq 0 ]]; then
-        echo "Error: specify '--set-mapping-staging' or '--set-mapping-production'." >&2
-        exit 1
-    fi
+    if [[ -n "$ARG_MAPPING_FILE" ]]; then
+        if [[ $map_staging -eq 0 && $map_production -eq 0 ]]; then
+            print_log "Error: specify '--set-mapping-staging' or '--set-mapping-production'." >&2
+            exit 1
+        fi
     fi
 
-    echo "Parsing args completed!"
+    print_log "Parsing args completed!"
+}
+
+parse_release_file()
+{
+    print_log "Parsing release file..."
+
+    # release yaml variables configured
+    declare -gA RELEASE_VARIABLES_CONFIGURED
+
+    # compose RELEASE_VARIABLES_CONFIGURED
+    local var_keys
+    var_keys=$(yq e '.variables | keys | .[]' "$ARG_RELEASE_FILE")
+
+    while IFS= read -r var; do
+        if [[ -n "$var" ]]; then
+            # Get the value for this variable
+            local value
+            value=$(yq e ".variables.$var" "$ARG_RELEASE_FILE")
+
+            # Check if the variable is allowed
+            if [[ -z "${RELEASE_VARIABLES_ALLOWED[$var]+_}" ]]; then
+                print_log "Error: Variable '$var' is not allowed in $ARG_RELEASE_FILE" >&2
+                exit 1
+            else
+                # Store in associative array
+                RELEASE_VARIABLES_CONFIGURED["$var"]="$value"
+            fi
+
+            print_log_debug "RELEASE_VARIABLES_CONFIGURED, key: $var, value: $value"
+        fi
+    done <<< "$var_keys"
+
+    print_log "Parsing release file completed!"
+    return 0
 }
 
 overlay_release()
 {
-    echo "Overlaying release..."
+    if [[ ! -f "$ARG_RELEASE_FILE" ]]; then
+        print_log "Skipping release overlay!"
+        return 0
+    fi
+    parse_release_file
 
-    local display_name="Lifecycle Agent"
-    local description="# Lifecycle Agent for OpenShift\nThe Lifecycle Agent for OpenShift
-    provides local lifecycle management services \nfor Single Node Openshift (SNO)
-    clusters.\n\n## Where to find more information\nYou can find additional guidance
-    in the [agent repository](https://github.com/openshift-kni/lifecycle-agent).\n"
-    local version="4.20.0"
-    local name="lifecycle-agent"
-    local name_version="$name.v$version"
-    local manager="lifecycle-agent-operator"
-    local skip_range=">=4.9.0 <4.20.0"
-    local replaces="lifecycle-agent.v4.20.0"
-    # min_kube_version should match ocp
-    # https://access.redhat.com/solutions/4870701
-    export min_kube_version="1.32.0"
+    print_log "Overlaying release..."
 
-    yq e -i ".metadata.annotations[\"containerImage\"] = \"${IMAGE_TO_TARGET[$MANAGER_KEY]}\"" $ARG_CSV_FILE
-    yq e -i ".spec.displayName = \"$display_name\"" $ARG_CSV_FILE
-    yq e -i ".spec.description = \"$description\""  $ARG_CSV_FILE
-    yq e -i ".spec.version = \"$version\"" $ARG_CSV_FILE
-    yq e -i ".metadata.name = \"$name_version\"" $ARG_CSV_FILE
-    yq e -i ".metadata.annotations[\"olm.skipRange\"] = \"$skip_range\"" $ARG_CSV_FILE
-    yq e -i ".spec.minKubeVersion = \"$min_kube_version\"" $ARG_CSV_FILE
+    # remove  the  existing  'skip_range' and 'replaces' from  the  upstream csv:
+    # the new values won't be applied by this overlay but managed via the catalog
+    # template (catalog-template.in.yaml)
+    print_log "Removing '.spec.replaces' and '.metadata.annotations[\"olm.skipRange\"]'"
+    yq e -i 'del(.spec.replaces)' "$ARG_CSV_FILE"
+    yq e -i 'del(.metadata.annotations["olm.skipRange"])' "$ARG_CSV_FILE"
 
-    # dont need 'replaces' for first release in a new channel (4.20.0)
-    yq e -i "del(.spec.replaces)" $ARG_CSV_FILE
+    for key in "${!RELEASE_VARIABLES_CONFIGURED[@]}"; do
+        local value=${RELEASE_VARIABLES_CONFIGURED[$key]}
+        local value_error=0
 
-    # use this from 4.20.1 onwards
-    # yq e -i ".spec.replaces = \"$replaces\"" $ARG_CSV_FILE
+        print_log_debug "RELEASE_VARIABLES_CONFIGURED, Key: $key, Value: $value"
 
-    # Special LCA considerations for the recert container
-    yq e -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].env[3].name = \"RELATED_IMAGE_RECERT_IMAGE\"" $ARG_CSV_FILE
-    RECERT_VALUE=$(yq '.[] | select(.key == "recert") | .target' "$ARG_PINNING_FILE")
-    yq e -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].env[3].value = \"$RECERT_VALUE\"" "$ARG_CSV_FILE"
+        case "$key" in
+            "alm_examples")
+                VALUE_ENV=$value yq e -i '.metadata.annotations["alm-examples"] = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "annotations")
+                yq e -i ".metadata.annotations += load(\"/dev/stdin\")" "$ARG_CSV_FILE" <<< "$value" || value_error=1
+                ;;
+            "containerImage")
+                if [[ "$value" == PLACEHOLDER_CONTAINER_IMAGE ]]; then
+                    value=${IMAGE_TO_TARGET["$MANAGER_KEY"]:-}
+                    if [[ -z "$value" ]]; then
+                        print_log "Error: no manager image pinned for key: $MANAGER_KEY. Check the pinning file: $ARG_PINNING_FILE" >&2
+                        value_error=1
+                    fi
+                fi
 
-    echo "Overlaying release completed!"
+                if [[ $value_error == 0 ]]; then
+                    VALUE_ENV=$value yq e -i '.metadata.annotations["containerImage"] = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                fi
+                ;;
+            "description")
+                VALUE_ENV=$value yq e -i '.spec.description = strenv(VALUE_ENV) | .spec.description style="literal"' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "display_name")
+                VALUE_ENV=$value yq e -i '.spec.displayName = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "manager_version")
+                VALUE_ENV=$value yq e -i '.metadata.name = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "subscription_badges")
+                VALUE_ENV=$value yq e -i '.metadata.annotations["operators.openshift.io/valid-subscription"] = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "version")
+                VALUE_ENV=$value yq e -i '.spec.version = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "min_kube_version")
+                VALUE_ENV=$value yq e -i '.spec.minKubeVersion = strenv(VALUE_ENV)' "$ARG_CSV_FILE" || value_error=1
+                ;;
+            "recert_image")
+                if [[ "$value" == PLACEHOLDER_RECERT_IMAGE ]]; then
+                    value=${IMAGE_TO_TARGET["$key"]:-}
+                    if [[ -z "$value" ]]; then
+                        print_log "Error: no recert image pinned for key: $key. Check the pinning file: $ARG_PINNING_FILE" >&2
+                        value_error=1
+                    fi
+                fi
+
+                if [[ $value_error == 0 ]]; then
+                    VALUE_ENV=$value yq e -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += {"name": "RELATED_IMAGE_RECERT_IMAGE", "value": "'"$value"'"}' "$ARG_CSV_FILE" || value_error=1
+                fi
+                ;;
+            *)
+                print_log "Error: no yq handler defined for release variable: $key" >&2
+                value_error=1
+                ;;
+            esac
+
+        if [[ $value_error -ne 0 ]]; then
+            print_log "Error: failed to set release variable: $key with value: $value on $ARG_CSV_FILE" >&2
+            exit 1
+        fi
+    done
+
+    print_log "Overlaying release completed!"
+    return 0
 }
 
 main() {
@@ -317,25 +431,29 @@ main() {
 }
 
 usage() {
-    cat << EOF
+   cat << EOF
 NAME
 
    $SCRIPT_NAME - overlay operator csv
 
 SYNOPSIS
 
-   $SCRIPT_NAME --set-pinning-file FILE [--set-mapping-file FILE (--set-mapping-staging|--set-mapping-production) --set-csv-file FILE
+   $SCRIPT_NAME --set-pinning-file FILE [--set-mapping-file FILE (--set-mapping-staging|--set-mapping-production)] [--set-release-file FILE] --set-csv-file FILE
 
 EXAMPLES
 
-   - Pin (sha256) images on 'lifecycle-agent.clusterserviceversion.yaml' according to the configuration on 'pin_images.in.yaml':
+   - Pin (sha256) images on 'oran-o2ims.clusterserviceversion.yaml' according to the configuration on 'pin_images.in.yaml':
 
-     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-csv-file lifecycle-agent.clusterserviceversion.yaml
+     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-csv-file oran-o2ims.clusterserviceversion.yaml
 
-   - Pin (sha256) images on 'lifecycle-agent.clusterserviceversion.yaml' according to the configuration on 'pin_images.in.yaml'
+   - Pin (sha256) images on 'oran-o2ims.clusterserviceversion.yaml' according to the configuration on 'pin_images.in.yaml'
      and map them to the production registry according to the configuration on 'map_images.in.yaml':
 
-     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-mapping-file map_images.in.yaml --set-mapping-production --set-csv-file lifecycle-agent.clusterserviceversion.yaml
+     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-mapping-file map_images.in.yaml --set-mapping-production --set-csv-file oran-o2ims.clusterserviceversion.yaml
+
+   - Ditto above and overlay the release according to the configuration on 'release.in.yaml':
+
+     $ $SCRIPT_NAME --set-pinning-file pin_images.in.yaml --set-mapping-file map_images.in.yaml --set-mapping-production --set-release-file release.in.yaml --set-csv-file oran-o2ims.clusterserviceversion.yaml
 
 DESCRIPTION
 
@@ -351,14 +469,17 @@ ARGS
 
       When used, it must be accompanied by either:
 
-    --set-mapping-staging    map to 'registry.stage.redhat.io'
-    --set-mapping-production map to 'registry.redhat.io'
+        --set-mapping-staging    map to 'registry.stage.redhat.io'
+        --set-mapping-production map to 'registry.redhat.io'
+
+   --set-release-file FILE
+      Set the release file for the overlay
 
    --set-csv-file FILE
       Set the cluster service version file
 
    --help
-      Display this help and exit.
+      Display this help and exit
 
 EOF
 }

--- a/test/TEST_OVERLAY.md
+++ b/test/TEST_OVERLAY.md
@@ -1,0 +1,371 @@
+
+# Test Overlay Framework Documentation
+
+This document explains the test code structure and usage for the Telco5G Konflux overlay testing framework.
+
+## Test Code Structure
+
+The test framework is organized hierarchically to support multiple operators, releases, and individual test scenarios. See this layout, highlighting a 4.20 release:
+
+```markdown:test/TEST_OVERLAY.md
+<code_block_to_apply_changes_from>
+test/overlay/
+├── runner.sh                     # Main test runner script
+├── lca/                          # Lifecycle Agent operator tests
+│   └── 4.20/                     # Release-specific tests
+│       ├── 00.test.sh            # Individual test script
+│       └── 00.data/              # Test data directory
+│           ├── expected/         # Expected output files
+│           ├── *.in.yaml         # Input files
+│          
+├── nrop/                         # NUMA Resources operator tests
+│   └── 4.20/
+│       ├── 00.test.sh
+│       └── 00.data/
+├── ocloud/                       # O-Cloud manager operator tests
+│   └── 4.20/
+│       ├── 00.test.sh
+│       └── 00.data/
+└── talm/                         # Topology Aware Lifecycle Manager tests
+    └── 4.20/
+        ├── 00.test.sh
+        └── 00.data/
+```
+
+### Directory Structure Explained
+
+- **`test/overlay/`**: Root directory for all overlay tests
+- **`<operator>/`**: Operator-specific test directories (`lca`, `nrop`, `ocloud`, `talm`)
+- **`<release>/`**: Release-specific test directories (e.g., `4.20`, `4.21`)
+- **`XX.test.sh`**: Individual test scripts (e.g., `00.test.sh`, `01.test.sh`)
+- **`XX.data/`**: Test data directory containing input files and expected outputs
+
+### Test Script Naming Convention
+
+Test scripts follow the pattern `XX.test.sh` where `XX` is a zero-padded number:
+- `00.test.sh` – Primary or basic test scenario
+- `01.test.sh`  Additional test scenario (if needed)
+- `02.test.sh` - Further test scenarios, etc.
+
+### Test Data Organization
+
+Each test has a corresponding data directory:
+- **Input files**: `map_images.in.yaml`, `pin_images.in.yaml`, `release.in.yaml`, `X.clusterserviceversion.in.yaml`, 
+- **Expected outputs**: `expected/` directory containing expected result files
+
+## Test Framework Components
+
+### 1. Main Test Runner (`runner.sh`)
+
+The central test execution script that:
+- Finds and executes all `*.test.sh` files in a given operator/release directory
+- Provides debug output capabilities
+- Reports test results and statistics
+- Handles test failures gracefully
+
+### 2. Individual Test Scripts (`XX.test.sh`)
+
+Each test script:
+- Sets up temporary directories for test execution
+- Validates input files exist
+- Executes the overlay transformation scripts
+- Compares actual output with expected results
+- Cleans up temporary files (unless debug mode is enabled)
+- Supports debug mode for troubleshooting and manually diff the files involved
+
+### 3. Overlay Scripts Integration
+
+Tests integrate with the main overlay scripts located in `scripts/bundle/`:
+- `konflux-bundle-overlay.sh` - Main overlay script
+- Tests validate the overlay process produces expected CSV modifications
+
+## Makefile Integration
+
+The test framework integrates with the project Makefile, providing multiple execution options:
+
+### Available Test Targets
+
+- `test-overlay` - Run all tests for all operators
+- `test-overlay-lca` - Run tests for Lifecycle Agent operator
+- `test-overlay-nrop` - Run tests for NUMA Resources operator  
+- `test-overlay-ocloud` - Run tests for O-Cloud manager operator
+- `test-overlay-talm` - Run tests for TALM operator
+
+### Makefile Parameters
+
+- **`RELEASE`**: Specify a particular release (e.g., `4.20`)
+- **`TEST`**: Specify a particular test file (e.g., `00.test.sh`)
+- **`DEBUG`**: Enable debug output (`DEBUG=1`)
+
+## Usage Examples
+
+Notice that depending on the number of tests run, the logs might be excessive.
+See [Debug Tip #0](#debug-tip-0) for advice on minimizing log output when running many tests.
+
+
+### Basic Usage - Run All Tests
+
+```bash
+# Run all tests for all operators and releases
+make test-overlay
+
+# Run all tests for a specific operator
+make test-overlay-lca
+make test-overlay-nrop
+make test-overlay-ocloud
+make test-overlay-talm
+```
+
+### Release-Specific Testing
+
+```bash
+# Run all tests for a specific operator and release
+make test-overlay-lca RELEASE=4.20
+make test-overlay-nrop RELEASE=4.20
+make test-overlay-ocloud RELEASE=4.20
+make test-overlay-talm RELEASE=4.20
+```
+
+### Specific Test Execution
+
+```bash
+# Run a specific test for a specific operator and release
+make test-overlay-lca RELEASE=4.20 TEST=00.test.sh
+make test-overlay-nrop RELEASE=4.20 TEST=00.test.sh
+make test-overlay-ocloud RELEASE=4.20 TEST=00.test.sh
+make test-overlay-talm RELEASE=4.20 TEST=00.test.sh
+
+# Run a specific test across ALL releases for an operator
+make test-overlay-lca TEST=00.test.sh
+make test-overlay-nrop TEST=00.test.sh
+make test-overlay-ocloud TEST=00.test.sh
+make test-overlay-talm TEST=00.test.sh
+
+# Run a specific test across ALL operators and releases
+make test-overlay TEST=00.test.sh
+```
+
+### Debug Mode Testing
+
+Debug mode preserves temporary files and shows detailed output.
+When a test is run with DEBUG=1, the logs will show a tmp file indicating that file(s) involved in the test can be checked there for troubleshooting.
+
+```
+[talm/4.21/00.test.sh] [DEBUG] Debug mode enabled for test operations 
+[talm/4.21/00.test.sh] [DEBUG] Temporary files will be preserved in: /tmp/tmp.N5Q2jTR8E5
+```
+
+Examples:
+
+```bash
+# Run with debug output for a specific test
+make test-overlay-lca RELEASE=4.20 TEST=00.test.sh DEBUG=1
+
+# Run with debug output for a complete release
+make test-overlay-lca RELEASE=4.20 DEBUG=1
+
+# Run with debug output for all tests
+make test-overlay DEBUG=1
+```
+
+### Cross-Release Testing
+
+These examples show how a specific test can be run across all releases
+
+```bash
+# Test a specific scenario across all LCA releases
+make test-overlay-lca TEST=00.test.sh
+
+# Test a specific scenario across all OCLOUD releases
+make test-overlay-ocloud TEST=00.test.sh
+
+# Test a specific scenario across all NROP releases
+make test-overlay-nrop TEST=00.test.sh
+
+# Test a specific scenario across all TALM releases
+make test-overlay-talm TEST=00.test.sh
+```
+
+### Advanced Combination Examples
+
+These examples show misc combos
+
+```bash
+# Test all scenarios for OCLOUD 4.20 with debug output
+make test-overlay-ocloud RELEASE=4.20 DEBUG=1
+
+# Test a specific scenario across all operators and releases
+make test-overlay TEST=00.test.sh
+
+# Quick validation of a specific operator/release/test combination
+make test-overlay-lca RELEASE=4.20 TEST=00.test.sh DEBUG=1
+make test-overlay-talm RELEASE=4.20 TEST=00.test.sh DEBUG=1
+
+# Cross-operator testing with debug for troubleshooting
+make test-overlay-lca TEST=00.test.sh DEBUG=1
+make test-overlay-nrop TEST=00.test.sh DEBUG=1
+make test-overlay-ocloud TEST=00.test.sh DEBUG=1
+make test-overlay-talm TEST=00.test.sh DEBUG=1
+```
+
+## Direct Script Usage
+
+You can also run the test framework directly without make:
+
+```bash
+# Navigate to test directory
+cd test/overlay
+
+# Run tests for specific operator and release
+./runner.sh lca 4.20
+./runner.sh ocloud 4.20 --debug
+
+# Run individual test script directly
+./lca/4.20/00.test.sh
+./lca/4.20/00.test.sh --debug
+```
+
+## Test Behavior
+
+### Success Criteria
+
+A test passes when:
+- The overlay script executes successfully
+- The actual output matches the expected output 
+- No errors occur during execution
+
+### Failure Handling
+
+Tests fail when:
+- The overlay script fails to execute
+- Output differs from expected results
+- Any validation step encounters an error
+
+### Cross-Release Testing Behavior
+
+When using `TEST=XX.test.sh` without `RELEASE`:
+- The framework searches all available releases for the specified operator
+- Runs the test for each release where the test file exists
+- Shows warnings for releases missing the test file
+- Fails if the test doesn't exist in ANY release
+- Stops execution if any test fails
+
+### Debug Mode Benefits
+
+When `DEBUG=1` is specified:
+- Temporary files are preserved for inspection
+- Detailed command output is shown
+- Test execution steps are logged
+- Easier troubleshooting of test failures
+
+## Adding New Tests
+
+### Creating a New Test Scenario
+
+1. **Copy existing test structure**:
+   ```bash
+   cp test/overlay/lca/4.20/00.test.sh test/overlay/lca/4.20/01.test.sh
+   cp -r test/overlay/lca/4.20/00.data test/overlay/lca/4.20/01.data
+   ```
+
+2. **Update test script references**:
+   ```bash
+   sed -i 's/00\.data/01.data/g' test/overlay/lca/4.20/01.test.sh
+   ```
+   And modify the input files and expected file accordingly.
+
+3. **Test the new scenario**:
+   ```bash
+   make test-overlay-lca RELEASE=4.20 TEST=01.test.sh DEBUG=1
+   ```
+
+### Adding a New Operator to test
+
+1. **Create operator directory structure**:
+   ```bash
+   mkdir -p test/overlay/newoperator/4.20/{00.data/expected}
+   ```
+
+2. **Create test script** following the existing pattern
+
+3. **Add to Makefile** - create new test target following existing pattern
+
+4. **Test the new operator**:
+   ```bash
+   make test-overlay-newoperator RELEASE=4.20 DEBUG=1
+   ```
+
+## Best Practices
+
+1. **Consistent Naming**: Follow the `XX.test.sh` and `XX.data/` naming pattern
+2. **Comprehensive Coverage**: Test both success and failure scenarios
+3. **Use Debug Mode**: Always test with `DEBUG=1` during development
+4. **Cross-Release Testing**: Use `TEST=XX.test.sh` to validate across releases
+5. **Clear Test Data**: Use descriptive file names and maintain clean test data
+6. **Expected Results**: Keep expected output files up to date
+7. **Incremental Testing**: Test specific changes before running full test suite
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Test file not found**: Ensure test script exists and follows naming convention
+2. **Permission errors**: Ensure test scripts are executable (`chmod +x *.test.sh`)
+3. **Missing dependencies**: Ensure `yq` and other required tools are installed
+4. **Path issues**: Run tests from the repository root or use Makefile targets
+
+### Debug Tips
+
+<a id="debug-tip-0"></a>
+
+0. **Minimize log output with grep**: When running all tests for an operator or all operators, logs can be excessive. Pipe the output through `grep runner.sh` to see a concise summary from the runner script and quickly check overall status.
+
+Example: run all 4.20 tests for all operators
+
+```bash
+$ make test-overlay RELEASE=4.20 | grep 'runner.sh'
+[runner.sh] Running tests for operator: lca, release: 4.20
+[runner.sh] Running test command: lca/4.20/00.test.sh
+[runner.sh] Test SUCCESS: lca/4.20/00.test.sh
+[runner.sh] Test summary for lca/4.20: Status=SUCCESS, Total=1, Passed=1, Failed=0
+[runner.sh] Running tests for operator: nrop, release: 4.20
+[runner.sh] Running test command: nrop/4.20/00.test.sh
+[runner.sh] Test SUCCESS: nrop/4.20/00.test.sh
+[runner.sh] Test summary for nrop/4.20: Status=SUCCESS, Total=1, Passed=1, Failed=0
+[runner.sh] Running tests for operator: ocloud, release: 4.20
+[runner.sh] Running test command: ocloud/4.20/00.test.sh
+[runner.sh] Test SUCCESS: ocloud/4.20/00.test.sh
+[runner.sh] Test summary for ocloud/4.20: Status=SUCCESS, Total=1, Passed=1, Failed=0
+[runner.sh] Running tests for operator: talm, release: 4.20
+[runner.sh] Running test command: talm/4.20/00.test.sh
+[runner.sh] Test SUCCESS: talm/4.20/00.test.sh
+[runner.sh] Running test command: talm/4.20/01.test.sh
+[runner.sh] Test SUCCESS: talm/4.20/01.test.sh
+[runner.sh] Test summary for talm/4.20: Status=SUCCESS, Total=2, Passed=2, Failed=0
+```
+
+1. **Use Debug Mode**: `DEBUG=1` preserves temporary files and shows detailed output
+2. **Run Individual Tests**: Use specific `RELEASE` and `TEST` parameters for focused debugging
+3. **Check Input Files**: Verify all input files exist and have correct content
+4. **Verify Scripts**: Ensure overlay scripts are accessible and executable
+5. **Compare Outputs**: Manually compare actual vs expected output files when tests fail
+6. **Incremental Approach**: Test one operator/release/test combination at a time when troubleshooting
+
+### Example Debug Workflow
+
+```bash
+# Start with specific test in debug mode
+make test-overlay-ocloud RELEASE=4.20 TEST=00.test.sh DEBUG=1
+
+# If that passes, test across releases
+make test-overlay-ocloud TEST=00.test.sh DEBUG=1
+
+# Then test all scenarios for that release
+make test-overlay-ocloud RELEASE=4.20 DEBUG=1
+
+# Test all tests across all releases
+make test-overlay-ocloud
+
+# Finally, test all 
+make test-overlay
+```

--- a/test/TEST_SHARED_FRAMEWORK.md
+++ b/test/TEST_SHARED_FRAMEWORK.md
@@ -1,0 +1,104 @@
+# Shared Test Framework for CSV Overlay Tests
+
+## Overview
+
+This directory uses a test framework that eliminates code duplication across multiple `XY.test.sh` 
+
+## Architecture
+
+### 1. Common Test Library (`common-test-lib.sh`)
+
+**Location**: `test/overlay/common-test-lib.sh`
+
+**Purpose**: Contains all shared functionality for CSV overlay testing, including:
+- Directory and logging setup
+- Debug mode handling
+- File path configuration
+- Input file validation
+- Cleanup management
+- Overlay script execution
+- Diff comparison with variant support
+
+### 2. Individual Test Files
+
+```bash
+#!/bin/bash
+
+# Source the common test library
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../../common-test-lib.sh
+
+# Initialize debug mode from command line argument
+init_debug_mode "${1:-}"
+
+# Run the CSV overlay test for <operator-name>
+run_csv_overlay_test "<csv-prefix>" "<description>" "<data-dir>"
+```
+
+## Usage
+
+### Basic Test Execution
+```bash
+./00.test.sh              # Run test normally
+./00.test.sh --debug      # Run test with debug output
+```
+
+### Main Function Parameters
+
+```bash
+run_csv_overlay_test "<csv-prefix>" "<description>" "<data-dir>"
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `csv-prefix` | Yes | - | Operator CSV filename prefix (e.g., `lifecycle-agent`) |
+| `description` | Yes | `- | A test description |
+| `data-dir` | Yes | `00.data` | Data directory (e.g., `00.data` for some tests) |
+
+### Examples
+
+```bash
+# Test using 01.data directory
+run_csv_overlay_test "cluster-group-upgrades-operator" "standard" "01.data"
+```
+
+## Benefits
+
+### Maintainability
+- **Single source of truth** for test logic
+- **Consistent behavior** across all tests
+- **Easy updates** - modify shared library once instead of 6+ files
+- **Better error handling** and logging
+
+### Functionality
+- **Preserved all existing functionality**
+- **Debug mode support** maintained
+- **Flexible data directory** support
+- **yq syntax variants** handled gracefully
+
+## File Structure
+
+```
+test/overlay/
+├── common-test-lib.sh              # Shared test framework
+├── lca/4.20/00.test.sh
+├── nrop/4.20/00.test.sh
+├── ocloud/4.20/00.test.sh
+├── talm/4.20/00.test.sh
+├── talm/4.20/01.test.sh
+└── talm/4.21/00.test.sh
+```
+
+## Future Considerations
+
+### Adding New Tests
+1. Create test data directory (`XX.data/`)
+2. Create minimal test script calling `run_csv_overlay_test`
+3. No duplicated code needed
+
+### Modifying Test Logic
+- Modify only `common-test-lib.sh`
+- All tests automatically inherit changes
+- No need to update multiple files
+
+### Custom Test Variants
+The framework is extensible. Add new functions to `common-test-lib.sh` for specialized test cases while maintaining the shared foundation.

--- a/test/overlay/common-test-lib.sh
+++ b/test/overlay/common-test-lib.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+# Common test library for CSV overlay tests
+# This file should be sourced by individual test scripts
+
+set -euo pipefail
+
+# Common variables setup
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[1]}")")
+RELEASE_DIR=$(basename "$SCRIPT_DIR")
+OPERATOR_DIR=$(basename "$(dirname "$SCRIPT_DIR")")
+SCRIPT_NAME=$(basename "$(readlink -f "${BASH_SOURCE[1]}")")
+SCRIPT_LOG="$OPERATOR_DIR/$RELEASE_DIR/$SCRIPT_NAME"
+
+# Common logging functions
+print_log() {
+    echo "[$SCRIPT_LOG] $1"
+}
+
+print_log_debug() {
+    if [[ "$DEBUG_ENABLED" == true ]]; then
+        print_log "[DEBUG] $1"
+    fi
+}
+
+# Initialize debug mode
+init_debug_mode() {
+    DEBUG_ENABLED=false
+    if [[ "${1:-}" == "--debug" ]]; then
+        DEBUG_ENABLED=true
+        print_log_debug "Debug mode enabled for test operations"
+    fi
+}
+
+# Setup test description
+setup_test_description() {
+    local test_description="$1"
+    print_log "Test description: $test_description"
+    print_log "Test path: $SCRIPT_DIR/$SCRIPT_NAME"
+}
+
+# Setup file paths for a given CSV prefix and data directory
+setup_file_paths() {
+    local csv_prefix="$1"
+    local data_dir="$2"
+
+    CSV_INPUT_FILE="$SCRIPT_DIR/$data_dir/${csv_prefix}.clusterserviceversion.in.yaml"
+    MAP_INPUT_FILE="$SCRIPT_DIR/$data_dir/map_images.in.yaml"
+    PIN_INPUT_FILE="$SCRIPT_DIR/$data_dir/pin_images.in.yaml"
+    RELEASE_INPUT_FILE="$SCRIPT_DIR/$data_dir/release.in.yaml"
+    CSV_EXPECTED_FILE="$SCRIPT_DIR/$data_dir/expected/${csv_prefix}.clusterserviceversion.yaml"
+
+    # Setup temporary directory and actual output file
+    TEMP_DIR=$(mktemp -d)
+    CSV_ACTUAL_FILE="$TEMP_DIR/${csv_prefix}.clusterserviceversion.yaml"
+    cp "$CSV_INPUT_FILE" "$CSV_ACTUAL_FILE"
+}
+
+# Validate all required files exist
+validate_input_files() {
+    local files=(
+        "$CSV_INPUT_FILE:CSV input file"
+        "$MAP_INPUT_FILE:Map images input file"
+        "$PIN_INPUT_FILE:Pin images input file"
+        "$RELEASE_INPUT_FILE:Release input file"
+        "$CSV_EXPECTED_FILE:Expected file"
+    )
+
+    for file_info in "${files[@]}"; do
+        local file_path="${file_info%%:*}"
+        local file_desc="${file_info##*:}"
+        if [[ ! -f "$file_path" ]]; then
+            print_log "Error: $file_desc not found: $file_path"
+            exit 1
+        fi
+    done
+}
+
+# Setup cleanup function and trap
+setup_cleanup() {
+    cleanup() {
+        # shellcheck disable=SC2317
+        rm -rf "$TEMP_DIR"
+    }
+
+    # Only set cleanup trap if debug is NOT enabled
+    if [[ "$DEBUG_ENABLED" != true ]]; then
+        trap cleanup EXIT
+    else
+        print_log_debug "Temporary files will be preserved in: $TEMP_DIR"
+    fi
+}
+
+# Validate overlay script exists
+validate_overlay_script() {
+    OVERLAY_DIR="$SCRIPT_DIR/../../../../scripts/bundle"
+    OVERLAY_SCRIPT="$OVERLAY_DIR/konflux-bundle-overlay.sh"
+
+    if [[ ! -f "$OVERLAY_SCRIPT" ]]; then
+        print_log "Error: overlay script not found: $OVERLAY_SCRIPT"
+        exit 1
+    fi
+}
+
+# Execute overlay command
+execute_overlay() {
+    local overlay_cmd=(
+        "$OVERLAY_SCRIPT"
+        --set-pinning-file "$PIN_INPUT_FILE"
+        --set-mapping-file "$MAP_INPUT_FILE"
+        --set-mapping-production
+        --set-release-file "$RELEASE_INPUT_FILE"
+        --set-csv-file "$CSV_ACTUAL_FILE"
+    )
+
+    print_log "Running overlay command: ${overlay_cmd[*]}"
+    if ! "${overlay_cmd[@]}"; then
+        print_log "FAILURE: Overlay command failed"
+        exit 1
+    fi
+}
+
+# Run diff comparison with optional yq syntax variant
+run_diff_comparison() {
+
+    local yq_del_expr="del(.metadata.annotations.createdAt)"
+
+    local diff_cmd="diff --unified=0 \
+        --ignore-space-change \
+        --ignore-blank-lines \
+        --ignore-trailing-space \
+        --label=\"actual CSV file: $CSV_ACTUAL_FILE\" <(yq e '$yq_del_expr' \"$CSV_ACTUAL_FILE\" | sed -r '/^[[:space:]]*#.*$/d') \
+        --label=\"expected CSV file: $CSV_EXPECTED_FILE\" <(yq e '$yq_del_expr' \"$CSV_EXPECTED_FILE\" | sed -r '/^[[:space:]]*#.*$/d')"
+
+    print_log "Running diff command: $diff_cmd"
+
+    if ! eval "$diff_cmd"; then
+        print_log "Test output: FAILURE. CSV files differ, see diff output above"
+        exit 1
+    fi
+    print_log "Test output: SUCCESS. CSV files match"
+}
+
+# Main test execution function
+run_csv_overlay_test() {
+    local csv_prefix="$1"
+    local test_description="$2"
+    local data_dir="$3"
+
+    setup_test_description "$test_description"
+    setup_file_paths "$csv_prefix" "$data_dir"
+    validate_input_files
+    setup_cleanup
+    validate_overlay_script
+    execute_overlay
+    run_diff_comparison
+    exit 0
+}

--- a/test/overlay/lca/4.20/00.data/expected/lifecycle-agent.clusterserviceversion.yaml
+++ b/test/overlay/lca/4.20/00.data/expected/lifecycle-agent.clusterserviceversion.yaml
@@ -1,0 +1,751 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "lca.openshift.io/v1",
+          "kind": "ImageBasedUpgrade",
+          "metadata": {
+            "name": "upgrade"
+          },
+          "spec": {
+            "autoRollbackOnFailure": {},
+            "extraManifests": [
+              {
+                "name": "sno-extramanifests",
+                "namespace": "openshift-lifecycle-agent"
+              }
+            ],
+            "oadpContent": [
+              {
+                "name": "oadp-cm-sno-backup",
+                "namespace": "openshift-adp"
+              }
+            ],
+            "seedImageRef": {
+              "image": "quay.io/xyz",
+              "version": "4.16.0"
+            },
+            "stage": "Idle"
+          }
+        },
+        {
+          "apiVersion": "lca.openshift.io/v1",
+          "kind": "SeedGenerator",
+          "metadata": {
+            "name": "seedimage"
+          },
+          "spec": {
+            "seedImage": "quay.io/xyz"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    containerImage: registry.redhat.io/openshift4/lifecycle-agent-rhel9-operator@sha256:5742926329c2e99c05d4f23e2da37fa9aac4dddc272cae9802776b09ae5043e6
+    description: The Lifecycle Agent for OpenShift provides local lifecycle management services for Single Node Openshift (SNO) clusters.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: openshift-lifecycle-agent
+    operatorframework.io/suggested-namespace-template: |-
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "openshift-lifecycle-agent",
+          "annotations": {
+            "workload.openshift.io/allowed": "management"
+          }
+        }
+      }
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    provider: Red Hat
+    repository: https://github.com/openshift-kni/lifecycle-agent
+    support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+  name: lifecycle-agent.v4.20.0
+  namespace: openshift-lifecycle-agent
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: ImageBasedUpgrade is the Schema for the ImageBasedUpgrades API
+        displayName: Image-based Cluster Upgrade
+        kind: ImageBasedUpgrade
+        name: imagebasedupgrades.lca.openshift.io
+        resources:
+          - kind: Deployment
+            name: ""
+            version: apps/v1
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: Auto Rollback On Failure
+            path: autoRollbackOnFailure
+          - description: InitMonitorTimeoutSeconds defines the time frame in seconds. If not defined or set to 0, the default value of 1800 seconds (30 minutes) is used.
+            displayName: Init Monitor Timeout Seconds
+            path: autoRollbackOnFailure.initMonitorTimeoutSeconds
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+          - description: ExtraManifests defines the list of ConfigMap resources that contain the user-specific extra manifests to be applied during the upgrade post-pivot stage. Users can also add their custom catalog sources that may want to retain after the upgrade.
+            displayName: Extra Manifests
+            path: extraManifests
+          - displayName: Name
+            path: extraManifests[0].name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Namespace
+            path: extraManifests[0].namespace
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: OADPContent defines the list of ConfigMap resources that contain the OADP Backup and Restore CRs.
+            displayName: OADP Content
+            path: oadpContent
+          - displayName: Name
+            path: oadpContent[0].name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Namespace
+            path: oadpContent[0].namespace
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Seed Image Reference
+            path: seedImageRef
+          - description: Image defines the full pull-spec of the seed container image to use.
+            displayName: Image
+            path: seedImageRef.image
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: PullSecretRef defines the reference to a secret with credentials to pull container images.
+            displayName: Pull Secret Reference
+            path: seedImageRef.pullSecretRef
+          - displayName: Name
+            path: seedImageRef.pullSecretRef.name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Version defines the target platform version. The value must match the version of the seed image.
+            displayName: Version
+            path: seedImageRef.version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Stage
+            path: stage
+        statusDescriptors:
+          - displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - displayName: Valid Next Stage
+            path: validNextStages
+        version: v1
+      - description: SeedGenerator is the Schema for the seedgenerators API
+        displayName: Seed Generator
+        kind: SeedGenerator
+        name: seedgenerators.lca.openshift.io
+        resources:
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: RecertImage defines the full pull-spec of the recert container image to use.
+            displayName: Recert Image
+            path: recertImage
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: SeedImage defines the full pull-spec of the seed container image to be created.
+            displayName: Seed Image
+            path: seedImage
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - displayName: Status
+            path: observedGeneration
+        version: v1
+  description: |-
+    Lifecycle Agent for OpenShift
+    The Lifecycle Agent for OpenShift provides local lifecycle management services
+    for Single Node Openshift (SNO) clusters.
+
+    You can find additional guidance in the upstream repository: https://github.com/openshift-kni/lifecycle-agent
+  displayName: Lifecycle Agent
+  icon:
+    - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/log
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs/status
+              verbs:
+                - get
+            - apiGroups:
+                - certificates.k8s.io
+              resources:
+                - certificatesigningrequests
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusteroperators
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - imagedigestmirrorsets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - infrastructures
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - proxies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumes
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - lca.openshift.io
+              resources:
+                - imagebasedupgrades
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - lca.openshift.io
+              resources:
+                - imagebasedupgrades/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - lca.openshift.io
+              resources:
+                - imagebasedupgrades/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - lca.openshift.io
+              resources:
+                - seedgenerators
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - lca.openshift.io
+              resources:
+                - seedgenerators/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - lca.openshift.io
+              resources:
+                - seedgenerators/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - local.storage.openshift.io
+              resources:
+                - localvolumes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - lvm.topolvm.io
+              resources:
+                - lvmclusters
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - machineconfiguration.openshift.io
+              resources:
+                - machineconfigpools
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - machineconfiguration.openshift.io
+              resources:
+                - machineconfigs
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheusrules
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - '*'
+            - apiGroups:
+                - oadp.openshift.io
+              resources:
+                - dataprotectionapplications
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - imagecontentsourcepolicies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - clusterserviceversions
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - subscriptions
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - policy.open-cluster-management.io
+              resources:
+                - policies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+              verbs:
+                - delete
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+              verbs:
+                - delete
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - privileged
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - sriovnetwork.openshift.io
+              resources:
+                - sriovnetworknodestates
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - velero.io
+              resources:
+                - backups
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - velero.io
+              resources:
+                - backupstoragelocations
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - velero.io
+              resources:
+                - deletebackuprequests
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - velero.io
+              resources:
+                - restores
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+          serviceAccountName: lifecycle-agent-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/component: lifecycle-agent
+            app.kubernetes.io/name: lifecycle-agent-operator
+            control-plane: controller-manager
+          name: lifecycle-agent-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: lifecycle-agent
+                app.kubernetes.io/name: lifecycle-agent-operator
+                control-plane: controller-manager
+            strategy:
+              type: Recreate
+            template:
+              metadata:
+                annotations:
+                  openshift.io/scc: privileged
+                  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                labels:
+                  app.kubernetes.io/component: lifecycle-agent
+                  app.kubernetes.io/name: lifecycle-agent-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-bind-address=:6443
+                      - --metrics-tls-cert-dir=/secrets/tls/metrics
+                    command:
+                      - /usr/local/bin/manager
+                    env:
+                      - name: PRECACHE_WORKLOAD_IMG
+                        value: registry.redhat.io/openshift4/lifecycle-agent-rhel9-operator@sha256:5742926329c2e99c05d4f23e2da37fa9aac4dddc272cae9802776b09ae5043e6
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: RELATED_IMAGE_RECERT_IMAGE
+                        value: registry.redhat.io/openshift4/recert-rhel9@sha256:c7a00a0202ca09c0c01d06ac6e073142a1ef3f5e437d94117a60898b24a757cc
+                    image: registry.redhat.io/openshift4/lifecycle-agent-rhel9-operator@sha256:5742926329c2e99c05d4f23e2da37fa9aac4dddc272cae9802776b09ae5043e6
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 6443
+                        name: https
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 20Mi
+                    securityContext:
+                      privileged: true
+                      readOnlyRootFilesystem: false
+                    tty: true
+                    volumeMounts:
+                      - mountPath: /host
+                        name: host-root
+                      - mountPath: /secrets/tls/metrics
+                        name: metrics-tls
+                hostPID: true
+                serviceAccountName: lifecycle-agent-controller-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - hostPath:
+                      path: /
+                      type: Directory
+                    name: host-root
+                  - name: metrics-tls
+                    secret:
+                      defaultMode: 420
+                      secretName: controller-manager-metrics-tls
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: lifecycle-agent-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - upgrade
+  links:
+    - name: Lifecycle Agent
+      url: https://lifecycle-agent.domain
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 4.20.0
+  relatedImages:
+    - name: manager
+      image: registry.redhat.io/openshift4/lifecycle-agent-rhel9-operator@sha256:5742926329c2e99c05d4f23e2da37fa9aac4dddc272cae9802776b09ae5043e6
+    - name: recert_image
+      image: registry.redhat.io/openshift4/recert-rhel9@sha256:c7a00a0202ca09c0c01d06ac6e073142a1ef3f5e437d94117a60898b24a757cc
+  minKubeVersion: 1.32.0

--- a/test/overlay/lca/4.20/00.data/lifecycle-agent.clusterserviceversion.in.yaml
+++ b/test/overlay/lca/4.20/00.data/lifecycle-agent.clusterserviceversion.in.yaml
@@ -1,0 +1,756 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "lca.openshift.io/v1",
+          "kind": "ImageBasedUpgrade",
+          "metadata": {
+            "name": "upgrade"
+          },
+          "spec": {
+            "autoRollbackOnFailure": {},
+            "extraManifests": [
+              {
+                "name": "sno-extramanifests",
+                "namespace": "openshift-lifecycle-agent"
+              }
+            ],
+            "oadpContent": [
+              {
+                "name": "oadp-cm-sno-backup",
+                "namespace": "openshift-adp"
+              }
+            ],
+            "seedImageRef": {
+              "image": "quay.io/xyz",
+              "version": "4.16.0"
+            },
+            "stage": "Idle"
+          }
+        },
+        {
+          "apiVersion": "lca.openshift.io/v1",
+          "kind": "SeedGenerator",
+          "metadata": {
+            "name": "seedimage"
+          },
+          "spec": {
+            "seedImage": "quay.io/xyz"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    containerImage: quay.io/openshift-kni/lifecycle-agent-operator
+    description: The Lifecycle Agent for OpenShift provides local lifecycle management
+      services for Single Node Openshift (SNO) clusters.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=4.14.0 <4.20.0'
+    operatorframework.io/suggested-namespace: openshift-lifecycle-agent
+    operatorframework.io/suggested-namespace-template: |-
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "openshift-lifecycle-agent",
+          "annotations": {
+            "workload.openshift.io/allowed": "management"
+          }
+        }
+      }
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    provider: Red Hat
+    repository: https://github.com/openshift-kni/lifecycle-agent
+    support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+  name: lifecycle-agent.v4.20.0
+  namespace: openshift-lifecycle-agent
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ImageBasedUpgrade is the Schema for the ImageBasedUpgrades API
+      displayName: Image-based Cluster Upgrade
+      kind: ImageBasedUpgrade
+      name: imagebasedupgrades.lca.openshift.io
+      resources:
+      - kind: Deployment
+        name: ""
+        version: apps/v1
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - displayName: Auto Rollback On Failure
+        path: autoRollbackOnFailure
+      - description: InitMonitorTimeoutSeconds defines the time frame in seconds.
+          If not defined or set to 0, the default value of 1800 seconds (30 minutes)
+          is used.
+        displayName: Init Monitor Timeout Seconds
+        path: autoRollbackOnFailure.initMonitorTimeoutSeconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: ExtraManifests defines the list of ConfigMap resources that contain
+          the user-specific extra manifests to be applied during the upgrade post-pivot
+          stage. Users can also add their custom catalog sources that may want to
+          retain after the upgrade.
+        displayName: Extra Manifests
+        path: extraManifests
+      - displayName: Name
+        path: extraManifests[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Namespace
+        path: extraManifests[0].namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: OADPContent defines the list of ConfigMap resources that contain
+          the OADP Backup and Restore CRs.
+        displayName: OADP Content
+        path: oadpContent
+      - displayName: Name
+        path: oadpContent[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Namespace
+        path: oadpContent[0].namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Seed Image Reference
+        path: seedImageRef
+      - description: Image defines the full pull-spec of the seed container image
+          to use.
+        displayName: Image
+        path: seedImageRef.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: PullSecretRef defines the reference to a secret with credentials
+          to pull container images.
+        displayName: Pull Secret Reference
+        path: seedImageRef.pullSecretRef
+      - displayName: Name
+        path: seedImageRef.pullSecretRef.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Version defines the target platform version. The value must match
+          the version of the seed image.
+        displayName: Version
+        path: seedImageRef.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Stage
+        path: stage
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - displayName: Valid Next Stage
+        path: validNextStages
+      version: v1
+    - description: SeedGenerator is the Schema for the seedgenerators API
+      displayName: Seed Generator
+      kind: SeedGenerator
+      name: seedgenerators.lca.openshift.io
+      resources:
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: RecertImage defines the full pull-spec of the recert container
+          image to use.
+        displayName: Recert Image
+        path: recertImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SeedImage defines the full pull-spec of the seed container image
+          to be created.
+        displayName: Seed Image
+        path: seedImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - displayName: Status
+        path: observedGeneration
+      version: v1
+  description: "# Lifecycle Agent for OpenShift\nThe Lifecycle Agent for OpenShift
+    provides local lifecycle management services \nfor Single Node Openshift (SNO)
+    clusters.\n\n## Where to find more information\nYou can find additional guidance
+    in the [agent repository](https://github.com/openshift-kni/lifecycle-agent).\n"
+  displayName: Openshift Lifecycle Agent
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs/status
+          verbs:
+          - get
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - imagedigestmirrorsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - lca.openshift.io
+          resources:
+          - imagebasedupgrades
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lca.openshift.io
+          resources:
+          - imagebasedupgrades/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - lca.openshift.io
+          resources:
+          - imagebasedupgrades/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - lca.openshift.io
+          resources:
+          - seedgenerators
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lca.openshift.io
+          resources:
+          - seedgenerators/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - lca.openshift.io
+          resources:
+          - seedgenerators/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - local.storage.openshift.io
+          resources:
+          - localvolumes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
+          - lvmclusters
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigpools
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - '*'
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - dataprotectionapplications
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - imagecontentsourcepolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy.open-cluster-management.io
+          resources:
+          - policies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - delete
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - sriovnetwork.openshift.io
+          resources:
+          - sriovnetworknodestates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backupstoragelocations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - deletebackuprequests
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - restores
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: lifecycle-agent-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: lifecycle-agent
+          app.kubernetes.io/name: lifecycle-agent-operator
+          control-plane: controller-manager
+        name: lifecycle-agent-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: lifecycle-agent
+              app.kubernetes.io/name: lifecycle-agent-operator
+              control-plane: controller-manager
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              annotations:
+                openshift.io/scc: privileged
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+              labels:
+                app.kubernetes.io/component: lifecycle-agent
+                app.kubernetes.io/name: lifecycle-agent-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:6443
+                - --metrics-tls-cert-dir=/secrets/tls/metrics
+                command:
+                - /usr/local/bin/manager
+                env:
+                - name: PRECACHE_WORKLOAD_IMG
+                  value: quay.io/openshift-kni/lifecycle-agent-operator:4.20.0
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: quay.io/openshift-kni/lifecycle-agent-operator:4.20.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 6443
+                  name: https
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  privileged: true
+                  readOnlyRootFilesystem: false
+                tty: true
+                volumeMounts:
+                - mountPath: /host
+                  name: host-root
+                - mountPath: /secrets/tls/metrics
+                  name: metrics-tls
+              hostPID: true
+              serviceAccountName: lifecycle-agent-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - hostPath:
+                  path: /
+                  type: Directory
+                name: host-root
+              - name: metrics-tls
+                secret:
+                  defaultMode: 420
+                  secretName: controller-manager-metrics-tls
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: lifecycle-agent-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - upgrade
+  links:
+  - name: Lifecycle Agent
+    url: https://lifecycle-agent.domain
+  maturity: alpha
+  provider:
+    name: Red Hat
+  replaces: lifecycle-agent.v0.0.0
+  version: 4.20.0

--- a/test/overlay/lca/4.20/00.data/map_images.in.yaml
+++ b/test/overlay/lca/4.20/00.data/map_images.in.yaml
@@ -1,0 +1,10 @@
+# Manager
+- key: manager
+  staging: registry.stage.redhat.io/openshift4/lifecycle-agent-rhel9-operator
+  production: registry.redhat.io/openshift4/lifecycle-agent-rhel9-operator
+#
+# Recert
+- key: recert_image
+  staging: registry.stage.redhat.io/openshift4/recert-rhel9
+  production: registry.redhat.io/openshift4/recert-rhel9
+#

--- a/test/overlay/lca/4.20/00.data/pin_images.in.yaml
+++ b/test/overlay/lca/4.20/00.data/pin_images.in.yaml
@@ -1,0 +1,10 @@
+# Manager
+- key: manager
+  source: quay.io/openshift-kni/lifecycle-agent-operator:4.20.0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-4-20@sha256:5742926329c2e99c05d4f23e2da37fa9aac4dddc272cae9802776b09ae5043e6 
+#
+# Recert
+- key: recert_image
+  source: quay.io/edge-infrastructure/recert:v0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/recert-4-20@sha256:c7a00a0202ca09c0c01d06ac6e073142a1ef3f5e437d94117a60898b24a757cc
+#

--- a/test/overlay/lca/4.20/00.data/release.in.yaml
+++ b/test/overlay/lca/4.20/00.data/release.in.yaml
@@ -1,0 +1,16 @@
+---
+variables:
+  # PLACEHOLDER_ variables will be substituted by ad-hoc overlay logic
+  containerImage: PLACEHOLDER_CONTAINER_IMAGE
+  description: |
+      Lifecycle Agent for OpenShift
+      The Lifecycle Agent for OpenShift provides local lifecycle management services
+      for Single Node Openshift (SNO) clusters.
+
+      You can find additional guidance in the upstream repository: https://github.com/openshift-kni/lifecycle-agent
+  display_name: "Lifecycle Agent"
+  manager_version: "lifecycle-agent.v4.20.0"
+  min_kube_version: "1.32.0"
+  recert_image: PLACEHOLDER_RECERT_IMAGE
+  version: "4.20.0"
+

--- a/test/overlay/lca/4.20/00.test.sh
+++ b/test/overlay/lca/4.20/00.test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Source the common test library
+# shellcheck source=test/overlay/common-test-lib.sh
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../../common-test-lib.sh
+
+# Initialize debug mode from command line argument
+init_debug_mode "${1:-}"
+
+# Run the CSV overlay test for lifecycle-agent operator
+run_csv_overlay_test "lifecycle-agent" "lifecycle-agent CSV overlay test" "00.data"

--- a/test/overlay/nrop/4.20/00.data/expected/numaresources-operator.clusterserviceversion.yaml
+++ b/test/overlay/nrop/4.20/00.data/expected/numaresources-operator.clusterserviceversion.yaml
@@ -1,0 +1,603 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "nodetopology.openshift.io/v1alpha1",
+          "kind": "NUMAResourcesOperator",
+          "metadata": {
+            "name": "numaresourcesoperator"
+          },
+          "spec": {
+            "nodeGroups": [
+              {
+                "machineConfigPoolSelector": {
+                  "matchLabels": {
+                    "pools.operator.machineconfiguration.openshift.io/worker": ""
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "nodetopology.openshift.io/v1alpha1",
+          "kind": "NUMAResourcesScheduler",
+          "metadata": {
+            "name": "numaresourcesscheduler"
+          },
+          "spec": {
+            "imageSpec": "URL_OF_SCHEDULER_IMAGE_FROM_REDHAT_REGISTRY",
+            "logLevel": "Normal",
+            "schedulerName": "topo-aware-scheduler"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-04-15T15:54:00Z"
+    operatorframework.io/cluster-monitoring: "true"
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    operators.openshift.io/valid-subscription: |-
+      [
+        "OpenShift Kubernetes Engine",
+        "OpenShift Container Platform",
+        "OpenShift Platform Plus"
+      ]
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+  name: numaresources-operator.v4.20.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators API
+        displayName: NUMA Resources Operator
+        kind: NUMAResourcesOperator
+        name: numaresourcesoperators.nodetopology.openshift.io
+        resources:
+          - kind: DaemonSet
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: Optional Resource Topology Exporter image URL
+            displayName: Optional RTE image URL
+            path: imageSpec
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+              Defaults to "Normal".
+            displayName: RTE log verbosity
+            path: logLevel
+          - description: Group of Nodes to enable RTE on
+            displayName: Group of nodes to enable RTE on
+            path: nodeGroups
+          - description: InfoRefreshMode sets the mechanism which will be used to refresh the topology info.
+            displayName: Topology info mechanism setting
+            path: nodeGroups[0].config.infoRefreshMode
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: InfoRefreshPause defines if updates to NRTs are paused for the machines belonging to this group
+            displayName: Enable or disable the RTE pause setting
+            path: nodeGroups[0].config.infoRefreshPause
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: InfoRefreshPeriod sets the topology info refresh period. Use explicit 0 to disable.
+            displayName: Topology info refresh period setting
+            path: nodeGroups[0].config.infoRefreshPeriod
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: PodsFingerprinting defines if pod fingerprint should be reported for the machines belonging to this group
+            displayName: Enable or disable the pods fingerprinting setting
+            path: nodeGroups[0].config.podsFingerprinting
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
+              Leave empty to make the system use the default tolerations.
+            displayName: Extra tolerations for the topology updater daemonset
+            path: nodeGroups[0].config.tolerations
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Optional Namespace/Name glob patterns of pod to ignore at node level
+            displayName: Optional ignore pod namespace/name glob patterns
+            path: podExcludes
+        statusDescriptors:
+          - description: Conditions show the current state of the NUMAResourcesOperator Operator
+            displayName: Condition reported
+            path: conditions
+          - description: DaemonSets of the configured RTEs, one per node group
+            displayName: RTE DaemonSets
+            path: daemonsets
+          - description: MachineConfigPools resolved from configured node groups
+            displayName: RTE MCPs from node groups
+            path: machineconfigpools
+          - description: Conditions represents the latest available observations of MachineConfigPool current state.
+            displayName: Optional conditions reported for this NodeGroup
+            path: machineconfigpools[0].conditions
+          - description: NodeGroupConfig represents the latest available configuration applied to this MachineConfigPool
+            displayName: Optional configuration enforced on this NodeGroup
+            path: machineconfigpools[0].config
+          - description: NodeGroups report the observed status of the configured NodeGroups, matching by their name
+            displayName: Node groups observed status
+            path: nodeGroups
+          - description: NodeGroupConfig represents the latest available configuration applied to this NodeGroup
+            displayName: Optional configuration enforced on this NodeGroup
+            path: nodeGroups[0].config
+          - description: DaemonSet of the configured RTEs, for this node group
+            displayName: RTE DaemonSets
+            path: nodeGroups[0].daemonsets
+          - description: PoolName represents the pool name to which the nodes belong that the config of this node group is be applied to
+            displayName: Pool name of nodes in this node group
+            path: nodeGroups[0].selector
+          - description: RelatedObjects list of objects of interest for this operator
+            displayName: Related Objects
+            path: relatedObjects
+        version: v1
+      - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators API
+        displayName: NUMA Resources Operator
+        kind: NUMAResourcesOperator
+        name: numaresourcesoperators.nodetopology.openshift.io
+        resources:
+          - kind: DaemonSet
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: Optional Resource Topology Exporter image URL
+            displayName: Optional RTE image URL
+            path: imageSpec
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+              Defaults to "Normal".
+            displayName: RTE log verbosity
+            path: logLevel
+          - description: Group of Nodes to enable RTE on
+            displayName: Group of nodes to enable RTE on
+            path: nodeGroups
+          - description: InfoRefreshMode sets the mechanism which will be used to refresh the topology info.
+            displayName: Topology info mechanism setting
+            path: nodeGroups[0].config.infoRefreshMode
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: InfoRefreshPeriod sets the topology info refresh period. Use explicit 0 to disable.
+            displayName: Topology info refresh period setting
+            path: nodeGroups[0].config.infoRefreshPeriod
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: PodsFingerprinting defines if pod fingerprint should be reported for the machines belonging to this group
+            displayName: Enable or disable the pods fingerprinting setting
+            path: nodeGroups[0].config.podsFingerprinting
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Optional Namespace/Name glob patterns of pod to ignore at node level
+            displayName: Optional ignore pod namespace/name glob patterns
+            path: podExcludes
+        statusDescriptors:
+          - description: Conditions show the current state of the NUMAResourcesOperator Operator
+            displayName: Condition reported
+            path: conditions
+          - description: DaemonSets of the configured RTEs, one per node group
+            displayName: RTE DaemonSets
+            path: daemonsets
+          - description: MachineConfigPools resolved from configured node groups
+            displayName: RTE MCPs from node groups
+            path: machineconfigpools
+          - description: Conditions represents the latest available observations of MachineConfigPool current state.
+            displayName: Optional conditions reported for this NodeGroup
+            path: machineconfigpools[0].conditions
+          - description: NodeGroupConfig represents the latest available configuration applied to this MachineConfigPool
+            displayName: Optional configuration enforced on this NodeGroup
+            path: machineconfigpools[0].config
+        version: v1alpha1
+      - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers API
+        displayName: NUMA Aware Scheduler
+        kind: NUMAResourcesScheduler
+        name: numaresourcesschedulers.nodetopology.openshift.io
+        resources:
+          - kind: Deployment
+            name: secondary-scheduler-deployment
+            version: v1
+        specDescriptors:
+          - description: Set the cache resync debug options. Defaults to disable.
+            displayName: Scheduler cache resync debug setting
+            path: cacheResyncDebug
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Set the cache resync detection mode. Default is to trigger resyncs only when detected guaranteed QoS pods which require NUMA-specific resources.
+            displayName: Scheduler cache resync detection setting
+            path: cacheResyncDetection
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Set the cache resync period. Use explicit 0 to disable.
+            displayName: Scheduler cache resync period setting
+            path: cacheResyncPeriod
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Scheduler container image URL
+            displayName: Scheduler container image URL
+            path: imageSpec
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+              Defaults to "Normal".
+            displayName: Scheduler log verbosity
+            path: logLevel
+          - description: Replicas control how many scheduler pods must be configured for High Availability (HA)
+            displayName: Scheduler replicas
+            path: replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:int
+          - description: Set the informer type to be used by the scheduler to connect to the apiserver. Defaults to dedicated.
+            displayName: Scheduler cache apiserver informer setting
+            path: schedulerInformer
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Scheduler name to be used in pod templates
+            displayName: Scheduler name
+            path: schedulerName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: ScoringStrategy a scoring model that determine how the plugin will score the nodes. Defaults to LeastAllocated.
+            displayName: Scheduler scoring strategy setting
+            path: scoringStrategy
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: CacheResyncPeriod shows the current cache resync period
+            displayName: Scheduler cache resync period
+            path: cacheResyncPeriod
+          - description: Deployment of the secondary scheduler, namespaced name
+            displayName: Scheduler deployment
+            path: deployment
+          - description: RelatedObjects list of objects of interest for this operator
+            displayName: Related Objects
+            path: relatedObjects
+          - description: Scheduler name to be used in pod templates
+            displayName: Scheduler name
+            path: schedulerName
+        version: v1
+      - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers API
+        displayName: NUMA Aware Scheduler
+        kind: NUMAResourcesScheduler
+        name: numaresourcesschedulers.nodetopology.openshift.io
+        resources:
+          - kind: Deployment
+            name: secondary-scheduler-deployment
+            version: v1
+        specDescriptors:
+          - description: Set the cache resync period. Use explicit 0 to disable.
+            displayName: Scheduler cache resync period setting
+            path: cacheResyncPeriod
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Scheduler container image URL
+            displayName: Scheduler container image URL
+            path: imageSpec
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+              Defaults to "Normal".
+            displayName: Scheduler log verbosity
+            path: logLevel
+          - description: Scheduler name to be used in pod templates
+            displayName: Scheduler name
+            path: schedulerName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: Deployment of the secondary scheduler, namespaced name
+            displayName: Scheduler deployment
+            path: deployment
+          - description: Scheduler name to be used in pod templates
+            displayName: Scheduler name
+            path: schedulerName
+        version: v1alpha1
+  description: NUMA resources exporter operator
+  displayName: numaresources-operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAYNJREFUWIXt1T9rlEEQx/HPnecJGoKJhY+NEgW5VrCxSZpr0oWUKcRgYSoLGwv1RfgWfAnWFlZWKQIRJE00V6XwTxQsdSwygWV5DEeaS/EMLDPP/Gaf/e7swz49hBlaf5aLdwAdQAfQAZwfgLa7OP4TT6tPMw/6TQaPK+EAcxhlXNs3NDngaaUvpx8XuRv4g+clAOzjBRZaFprGPuN1ldtoqXuEXWzWAEdYwvczAiylH6W/iCctdZt4hit4UAJcwDAT984IsYVPGa+26CsY4D3e4MOJ0BA7x99GjIkgesQXYo4YZawaX4nrRJNzFoi9nBvE/fTjrI8ciDvEEXGZGJSU79I/xN+Mf2Gx2s0lzOMnrmbuB+4Wu98u6ufxGxPsZG6A9boDiJtJOskOILYL+n7Gb/O5KbQ14iPxqtj1mNgqaqg6UgMgXqZ4AnArn/fzOIK41gIwzKO5XQEEsVqtMSQOj49MBHpVm+tcfYHUWu+UuO39tT4zOx//gg6gA+gAOoBZ2j82IbSJZWt9tAAAAABJRU5ErkJggg==
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+              verbs:
+                - '*'
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusteroperators
+                - infrastructures
+              verbs:
+                - get
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+              verbs:
+                - list
+            - apiGroups:
+                - machineconfiguration.openshift.io
+              resources:
+                - kubeletconfigs
+                - machineconfigpools
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - machineconfiguration.openshift.io
+              resources:
+                - kubeletconfigs/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - machineconfiguration.openshift.io
+              resources:
+                - machineconfigs
+              verbs:
+                - '*'
+            - apiGroups:
+                - nodetopology.openshift.io
+              resources:
+                - numaresourcesoperators
+              verbs:
+                - '*'
+            - apiGroups:
+                - nodetopology.openshift.io
+              resources:
+                - numaresourcesoperators/finalizers
+                - numaresourcesschedulers/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - nodetopology.openshift.io
+              resources:
+                - numaresourcesoperators/status
+                - numaresourcesschedulers/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - nodetopology.openshift.io
+              resources:
+                - numaresourcesschedulers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - '*'
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - '*'
+            - apiGroups:
+                - topology.node.k8s.io
+              resources:
+                - noderesourcetopologies
+              verbs:
+                - create
+                - get
+                - list
+                - update
+          serviceAccountName: numaresources-controller-manager
+      deployments:
+        - label:
+            app: numaresources-operator
+            control-plane: controller-manager
+          name: numaresources-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                labels:
+                  app: numaresources-operator
+                  control-plane: controller-manager
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/control-plane
+                              operator: Exists
+                        weight: 1
+                containers:
+                  - args:
+                      - -v=4
+                    command:
+                      - /bin/numaresources-operator
+                    env:
+                      - name: PODNAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: registry.redhat.io/openshift4/numaresources-rhel9-operator@sha256:746b9854b2f9ac1657d0690df57d99b1647684813b5dcf95ebdcb80d53d3aa95
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 8080
+                        name: https
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 20Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                    volumeMounts:
+                      - mountPath: /certs
+                        name: metrics-tls
+                        readOnly: true
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: numaresources-controller-manager
+                terminationGracePeriodSeconds: 10
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                volumes:
+                  - name: metrics-tls
+                    secret:
+                      secretName: metrics-service-cert
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - '*'
+          serviceAccountName: numaresources-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - RTE
+    - NUMA
+  links:
+    - name: Numaresources Operator
+      url: https://github.com/openshift-kni/numaresources-operator
+  maintainers:
+    - email: fromani@redhat.com
+      name: fromani
+  maturity: stable
+  minKubeVersion: 1.23.0
+  provider:
+    name: Red Hat
+  version: 4.20.0
+  relatedImages:
+    - name: manager
+      image: registry.redhat.io/openshift4/numaresources-rhel9-operator@sha256:746b9854b2f9ac1657d0690df57d99b1647684813b5dcf95ebdcb80d53d3aa95

--- a/test/overlay/nrop/4.20/00.data/map_images.in.yaml
+++ b/test/overlay/nrop/4.20/00.data/map_images.in.yaml
@@ -1,0 +1,4 @@
+# Do not modify the manager 'key' value: 'manager'
+- key: manager
+  staging: registry.stage.redhat.io/openshift4/numaresources-rhel9-operator
+  production: registry.redhat.io/openshift4/numaresources-rhel9-operator

--- a/test/overlay/nrop/4.20/00.data/numaresources-operator.clusterserviceversion.in.yaml
+++ b/test/overlay/nrop/4.20/00.data/numaresources-operator.clusterserviceversion.in.yaml
@@ -1,0 +1,637 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "nodetopology.openshift.io/v1",
+          "kind": "NUMAResourcesOperator",
+          "metadata": {
+            "name": "numaresourcesoperator"
+          },
+          "spec": {
+            "nodeGroups": [
+              {
+                "machineConfigPoolSelector": {
+                  "matchLabels": {
+                    "pools.operator.machineconfiguration.openshift.io/worker": ""
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "nodetopology.openshift.io/v1",
+          "kind": "NUMAResourcesScheduler",
+          "metadata": {
+            "name": "numaresourcesscheduler"
+          },
+          "spec": {
+            "imageSpec": "quay.io/openshift-kni/scheduler-plugins:4.20-snapshot"
+          }
+        },
+        {
+          "apiVersion": "nodetopology.openshift.io/v1alpha1",
+          "kind": "NUMAResourcesOperator",
+          "metadata": {
+            "name": "numaresourcesoperator"
+          },
+          "spec": {
+            "nodeGroups": [
+              {
+                "machineConfigPoolSelector": {
+                  "matchLabels": {
+                    "pools.operator.machineconfiguration.openshift.io/worker": ""
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "nodetopology.openshift.io/v1alpha1",
+          "kind": "NUMAResourcesScheduler",
+          "metadata": {
+            "name": "numaresourcesscheduler"
+          },
+          "spec": {
+            "imageSpec": "quay.io/openshift-kni/scheduler-plugins:4.20-snapshot"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-04-15T15:54:00Z"
+    operatorframework.io/cluster-monitoring: "true"
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  name: numaresources-operator.v4.20.999-snapshot
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators
+        API
+      displayName: NUMA Resources Operator
+      kind: NUMAResourcesOperator
+      name: numaresourcesoperators.nodetopology.openshift.io
+      resources:
+      - kind: DaemonSet
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Optional Resource Topology Exporter image URL
+        displayName: Optional RTE image URL
+        path: imageSpec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
+        displayName: RTE log verbosity
+        path: logLevel
+      - description: Group of Nodes to enable RTE on
+        displayName: Group of nodes to enable RTE on
+        path: nodeGroups
+      - description: InfoRefreshMode sets the mechanism which will be used to refresh
+          the topology info.
+        displayName: Topology info mechanism setting
+        path: nodeGroups[0].config.infoRefreshMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: InfoRefreshPause defines if updates to NRTs are paused for the
+          machines belonging to this group
+        displayName: Enable or disable the RTE pause setting
+        path: nodeGroups[0].config.infoRefreshPause
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: InfoRefreshPeriod sets the topology info refresh period. Use
+          explicit 0 to disable.
+        displayName: Topology info refresh period setting
+        path: nodeGroups[0].config.infoRefreshPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: PodsFingerprinting defines if pod fingerprint should be reported
+          for the machines belonging to this group
+        displayName: Enable or disable the pods fingerprinting setting
+        path: nodeGroups[0].config.podsFingerprinting
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
+          Leave empty to make the system use the default tolerations.
+        displayName: Extra tolerations for the topology updater daemonset
+        path: nodeGroups[0].config.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Optional Namespace/Name glob patterns of pod to ignore at node
+          level
+        displayName: Optional ignore pod namespace/name glob patterns
+        path: podExcludes
+      statusDescriptors:
+      - description: Conditions show the current state of the NUMAResourcesOperator
+          Operator
+        displayName: Condition reported
+        path: conditions
+      - description: DaemonSets of the configured RTEs, one per node group
+        displayName: RTE DaemonSets
+        path: daemonsets
+      - description: MachineConfigPools resolved from configured node groups
+        displayName: RTE MCPs from node groups
+        path: machineconfigpools
+      - description: Conditions represents the latest available observations of MachineConfigPool
+          current state.
+        displayName: Optional conditions reported for this NodeGroup
+        path: machineconfigpools[0].conditions
+      - description: NodeGroupConfig represents the latest available configuration
+          applied to this MachineConfigPool
+        displayName: Optional configuration enforced on this NodeGroup
+        path: machineconfigpools[0].config
+      - description: NodeGroups report the observed status of the configured NodeGroups,
+          matching by their name
+        displayName: Node groups observed status
+        path: nodeGroups
+      - description: NodeGroupConfig represents the latest available configuration
+          applied to this NodeGroup
+        displayName: Optional configuration enforced on this NodeGroup
+        path: nodeGroups[0].config
+      - description: DaemonSet of the configured RTEs, for this node group
+        displayName: RTE DaemonSets
+        path: nodeGroups[0].daemonsets
+      - description: PoolName represents the pool name to which the nodes belong that
+          the config of this node group is be applied to
+        displayName: Pool name of nodes in this node group
+        path: nodeGroups[0].selector
+      - description: RelatedObjects list of objects of interest for this operator
+        displayName: Related Objects
+        path: relatedObjects
+      version: v1
+    - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators
+        API
+      displayName: NUMA Resources Operator
+      kind: NUMAResourcesOperator
+      name: numaresourcesoperators.nodetopology.openshift.io
+      resources:
+      - kind: DaemonSet
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Optional Resource Topology Exporter image URL
+        displayName: Optional RTE image URL
+        path: imageSpec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
+        displayName: RTE log verbosity
+        path: logLevel
+      - description: Group of Nodes to enable RTE on
+        displayName: Group of nodes to enable RTE on
+        path: nodeGroups
+      - description: InfoRefreshMode sets the mechanism which will be used to refresh
+          the topology info.
+        displayName: Topology info mechanism setting
+        path: nodeGroups[0].config.infoRefreshMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: InfoRefreshPeriod sets the topology info refresh period. Use
+          explicit 0 to disable.
+        displayName: Topology info refresh period setting
+        path: nodeGroups[0].config.infoRefreshPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: PodsFingerprinting defines if pod fingerprint should be reported
+          for the machines belonging to this group
+        displayName: Enable or disable the pods fingerprinting setting
+        path: nodeGroups[0].config.podsFingerprinting
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Optional Namespace/Name glob patterns of pod to ignore at node
+          level
+        displayName: Optional ignore pod namespace/name glob patterns
+        path: podExcludes
+      statusDescriptors:
+      - description: Conditions show the current state of the NUMAResourcesOperator
+          Operator
+        displayName: Condition reported
+        path: conditions
+      - description: DaemonSets of the configured RTEs, one per node group
+        displayName: RTE DaemonSets
+        path: daemonsets
+      - description: MachineConfigPools resolved from configured node groups
+        displayName: RTE MCPs from node groups
+        path: machineconfigpools
+      - description: Conditions represents the latest available observations of MachineConfigPool
+          current state.
+        displayName: Optional conditions reported for this NodeGroup
+        path: machineconfigpools[0].conditions
+      - description: NodeGroupConfig represents the latest available configuration
+          applied to this MachineConfigPool
+        displayName: Optional configuration enforced on this NodeGroup
+        path: machineconfigpools[0].config
+      version: v1alpha1
+    - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers
+        API
+      displayName: NUMA Aware Scheduler
+      kind: NUMAResourcesScheduler
+      name: numaresourcesschedulers.nodetopology.openshift.io
+      resources:
+      - kind: Deployment
+        name: secondary-scheduler-deployment
+        version: v1
+      specDescriptors:
+      - description: Set the cache resync debug options. Defaults to disable.
+        displayName: Scheduler cache resync debug setting
+        path: cacheResyncDebug
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Set the cache resync detection mode. Default is to trigger resyncs
+          only when detected guaranteed QoS pods which require NUMA-specific resources.
+        displayName: Scheduler cache resync detection setting
+        path: cacheResyncDetection
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Set the cache resync period. Use explicit 0 to disable.
+        displayName: Scheduler cache resync period setting
+        path: cacheResyncPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Scheduler container image URL
+        displayName: Scheduler container image URL
+        path: imageSpec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
+        displayName: Scheduler log verbosity
+        path: logLevel
+      - description: Replicas control how many scheduler pods must be configured for
+          High Availability (HA)
+        displayName: Scheduler replicas
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:int
+      - description: Set the informer type to be used by the scheduler to connect
+          to the apiserver. Defaults to dedicated.
+        displayName: Scheduler cache apiserver informer setting
+        path: schedulerInformer
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Scheduler name to be used in pod templates
+        displayName: Scheduler name
+        path: schedulerName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ScoringStrategy a scoring model that determine how the plugin
+          will score the nodes. Defaults to LeastAllocated.
+        displayName: Scheduler scoring strategy setting
+        path: scoringStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: CacheResyncPeriod shows the current cache resync period
+        displayName: Scheduler cache resync period
+        path: cacheResyncPeriod
+      - description: Deployment of the secondary scheduler, namespaced name
+        displayName: Scheduler deployment
+        path: deployment
+      - description: RelatedObjects list of objects of interest for this operator
+        displayName: Related Objects
+        path: relatedObjects
+      - description: Scheduler name to be used in pod templates
+        displayName: Scheduler name
+        path: schedulerName
+      version: v1
+    - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers
+        API
+      displayName: NUMA Aware Scheduler
+      kind: NUMAResourcesScheduler
+      name: numaresourcesschedulers.nodetopology.openshift.io
+      resources:
+      - kind: Deployment
+        name: secondary-scheduler-deployment
+        version: v1
+      specDescriptors:
+      - description: Set the cache resync period. Use explicit 0 to disable.
+        displayName: Scheduler cache resync period setting
+        path: cacheResyncPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Scheduler container image URL
+        displayName: Scheduler container image URL
+        path: imageSpec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
+        displayName: Scheduler log verbosity
+        path: logLevel
+      - description: Scheduler name to be used in pod templates
+        displayName: Scheduler name
+        path: schedulerName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Deployment of the secondary scheduler, namespaced name
+        displayName: Scheduler deployment
+        path: deployment
+      - description: Scheduler name to be used in pod templates
+        displayName: Scheduler name
+        path: schedulerName
+      version: v1alpha1
+  description: NUMA resources exporter operator
+  displayName: numaresources-operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAYNJREFUWIXt1T9rlEEQx/HPnecJGoKJhY+NEgW5VrCxSZpr0oWUKcRgYSoLGwv1RfgWfAnWFlZWKQIRJE00V6XwTxQsdSwygWV5DEeaS/EMLDPP/Gaf/e7swz49hBlaf5aLdwAdQAfQAZwfgLa7OP4TT6tPMw/6TQaPK+EAcxhlXNs3NDngaaUvpx8XuRv4g+clAOzjBRZaFprGPuN1ldtoqXuEXWzWAEdYwvczAiylH6W/iCctdZt4hit4UAJcwDAT984IsYVPGa+26CsY4D3e4MOJ0BA7x99GjIkgesQXYo4YZawaX4nrRJNzFoi9nBvE/fTjrI8ciDvEEXGZGJSU79I/xN+Mf2Gx2s0lzOMnrmbuB+4Wu98u6ufxGxPsZG6A9boDiJtJOskOILYL+n7Gb/O5KbQ14iPxqtj1mNgqaqg6UgMgXqZ4AnArn/fzOIK41gIwzKO5XQEEsVqtMSQOj49MBHpVm+tcfYHUWu+UuO39tT4zOx//gg6gA+gAOoBZ2j82IbSJZWt9tAAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusteroperators
+          - infrastructures
+          verbs:
+          - get
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - list
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - kubeletconfigs
+          - machineconfigpools
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - kubeletconfigs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - nodetopology.openshift.io
+          resources:
+          - numaresourcesoperators
+          verbs:
+          - '*'
+        - apiGroups:
+          - nodetopology.openshift.io
+          resources:
+          - numaresourcesoperators/finalizers
+          - numaresourcesschedulers/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - nodetopology.openshift.io
+          resources:
+          - numaresourcesoperators/status
+          - numaresourcesschedulers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - nodetopology.openshift.io
+          resources:
+          - numaresourcesschedulers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - '*'
+        - apiGroups:
+          - topology.node.k8s.io
+          resources:
+          - noderesourcetopologies
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        serviceAccountName: numaresources-controller-manager
+      deployments:
+      - label:
+          app: numaresources-operator
+          control-plane: controller-manager
+        name: numaresources-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+              labels:
+                app: numaresources-operator
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - preference:
+                      matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                    weight: 1
+              containers:
+              - args:
+                - -v=4
+                command:
+                - /bin/numaresources-operator
+                env:
+                - name: PODNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: quay.io/openshift-kni/numaresources-operator:4.20.999-snapshot
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 8080
+                  name: https
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                volumeMounts:
+                - mountPath: /certs
+                  name: metrics-tls
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: numaresources-controller-manager
+              terminationGracePeriodSeconds: 10
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+              volumes:
+              - name: metrics-tls
+                secret:
+                  secretName: metrics-service-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - '*'
+        serviceAccountName: numaresources-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - RTE
+  - NUMA
+  links:
+  - name: Numaresources Operator
+    url: https://github.com/openshift-kni/numaresources-operator
+  maintainers:
+  - email: fromani@redhat.com
+    name: fromani
+  maturity: stable
+  minKubeVersion: 1.23.0
+  provider:
+    name: Red Hat
+  replaces: numaresources-operator.v4.19.999-snapshot
+  version: 4.20.999-snapshot

--- a/test/overlay/nrop/4.20/00.data/pin_images.in.yaml
+++ b/test/overlay/nrop/4.20/00.data/pin_images.in.yaml
@@ -1,0 +1,5 @@
+# Do not modify the manager 'key' value: 'manager'
+- key: manager
+  source: quay.io/openshift-kni/numaresources-operator:4.20.999-snapshot
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-4-20@sha256:746b9854b2f9ac1657d0690df57d99b1647684813b5dcf95ebdcb80d53d3aa95
+

--- a/test/overlay/nrop/4.20/00.data/release.in.yaml
+++ b/test/overlay/nrop/4.20/00.data/release.in.yaml
@@ -1,0 +1,56 @@
+---
+variables:
+  annotations: |
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+  alm_examples: |
+   [
+    {
+      "apiVersion": "nodetopology.openshift.io/v1alpha1",
+      "kind": "NUMAResourcesOperator",
+      "metadata": {
+        "name": "numaresourcesoperator"
+      },
+      "spec": {
+        "nodeGroups": [
+          {
+            "machineConfigPoolSelector": {
+              "matchLabels": {
+                "pools.operator.machineconfiguration.openshift.io/worker": ""
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "nodetopology.openshift.io/v1alpha1",
+      "kind": "NUMAResourcesScheduler",
+      "metadata": {
+        "name": "numaresourcesscheduler"
+      },
+      "spec": {
+        "imageSpec": "URL_OF_SCHEDULER_IMAGE_FROM_REDHAT_REGISTRY",
+        "logLevel": "Normal",
+        "schedulerName": "topo-aware-scheduler"
+      }
+    }
+   ]
+  display_name: "numaresources-operator"
+  manager_version: "numaresources-operator.v4.20.0"
+  subscription_badges: |
+   [
+     "OpenShift Kubernetes Engine",
+     "OpenShift Container Platform",
+     "OpenShift Platform Plus"
+   ]
+  version: "4.20.0"
+

--- a/test/overlay/nrop/4.20/00.test.sh
+++ b/test/overlay/nrop/4.20/00.test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Source the common test library
+# shellcheck source=test/overlay/common-test-lib.sh
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../../common-test-lib.sh
+
+# Initialize debug mode from command line argument
+init_debug_mode "${1:-}"
+
+# Run the CSV overlay test for numaresources-operator (with fallback yq syntax)
+run_csv_overlay_test "numaresources-operator" "numaresources-operator CSV overlay test" "00.data"

--- a/test/overlay/ocloud/4.20/00.data/expected/oran-o2ims.clusterserviceversion.yaml
+++ b/test/overlay/ocloud/4.20/00.data/expected/oran-o2ims.clusterserviceversion.yaml
@@ -1,0 +1,1998 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "ClusterTemplate",
+          "metadata": {
+            "name": "clustertemplate-sample.v1.0.0",
+            "namespace": "clustertemplate-a-v4-16-3"
+          },
+          "spec": {
+            "characteristics": {
+              "age": "31"
+            },
+            "description": "nice description",
+            "metadata": {
+              "apple": "23"
+            },
+            "name": "clustertemplate-a",
+            "release": "4.16.3",
+            "templateParameterSchema": {
+              "properties": {
+                "clusterInstanceParameters": {
+                  "description": "clusterInstanceParameters defines the available parameters for cluster installation",
+                  "properties": {
+                    "additionalNTPSources": {
+                      "description": "AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster hosts. They are added to any NTP sources that were configured through other means.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "apiVIPs": {
+                      "description": "APIVIPs are the virtual IPs used to reach the OpenShift cluster's API. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "baseDomain": {
+                      "description": "BaseDomain is the base domain to use for the deployed cluster.",
+                      "type": "string"
+                    },
+                    "clusterName": {
+                      "description": "ClusterName is the name of the cluster.",
+                      "type": "string"
+                    },
+                    "extraAnnotations": {
+                      "additionalProperties": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "description": "Additional cluster-wide annotations to be applied to the rendered templates",
+                      "type": "object"
+                    },
+                    "extraLabels": {
+                      "additionalProperties": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "description": "Additional cluster-wide labels to be applied to the rendered templates",
+                      "type": "object"
+                    },
+                    "ingressVIPs": {
+                      "description": "IngressVIPs are the virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "machineNetwork": {
+                      "description": "MachineNetwork is the list of IP address pools for machines.",
+                      "items": {
+                        "description": "MachineNetworkEntry is a single IP address block for node IP blocks.",
+                        "properties": {
+                          "cidr": {
+                            "description": "CIDR is the IP block address pool for machines within the cluster.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "cidr"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodes": {
+                      "items": {
+                        "description": "NodeSpec",
+                        "properties": {
+                          "extraAnnotations": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "description": "Additional node-level annotations to be applied to the rendered templates",
+                            "type": "object"
+                          },
+                          "extraLabels": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "description": "Additional node-level labels to be applied to the rendered templates",
+                            "type": "object"
+                          },
+                          "hostName": {
+                            "description": "Hostname is the desired hostname for the host",
+                            "type": "string"
+                          },
+                          "nodeLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "NodeLabels allows the specification of custom roles for your nodes in your managed clusters. These are additional roles are not used by any OpenShift Container Platform components, only by the user. When you add a custom role, it can be associated with a custom machine config pool that references a specific configuration for that role. Adding custom labels or roles during installation makes the deployment process more effective and prevents the need for additional reboots after the installation is complete.",
+                            "type": "object"
+                          },
+                          "nodeNetwork": {
+                            "description": "NodeNetwork is a set of configurations pertaining to the network settings for the node.",
+                            "properties": {
+                              "config": {
+                                "description": "yaml that can be processed by nmstate, using custom marshaling/unmarshaling that will allow to populate nmstate config as plain yaml.",
+                                "type": "object",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "hostName"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "serviceNetwork": {
+                      "description": "ServiceNetwork is the list of IP address pools for services.",
+                      "items": {
+                        "description": "ServiceNetworkEntry is a single IP address block for node IP blocks.",
+                        "properties": {
+                          "cidr": {
+                            "description": "CIDR is the IP block address pool for machines within the cluster.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "cidr"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "sshPublicKey": {
+                      "description": "SSHPublicKey is the public Secure Shell (SSH) key to provide access to instances. This key will be added to the host to allow ssh access",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "clusterName",
+                    "nodes"
+                  ],
+                  "type": "object"
+                },
+                "nodeClusterName": {
+                  "type": "string"
+                },
+                "oCloudSiteId": {
+                  "type": "string"
+                },
+                "policyTemplateParameters": {
+                  "description": "policyTemplateParameters defines the available parameters for cluster configuration",
+                  "properties": {
+                    "cpu-isolated": {
+                      "type": "string"
+                    },
+                    "cpu-reserved": {
+                      "type": "string"
+                    },
+                    "hugepages-count": {
+                      "type": "string"
+                    },
+                    "hugepages-default": {
+                      "type": "string"
+                    },
+                    "hugepages-size": {
+                      "type": "string"
+                    },
+                    "install-plan-approval": {
+                      "type": "string"
+                    },
+                    "sriov-network-pfNames-1": {
+                      "type": "string"
+                    },
+                    "sriov-network-pfNames-2": {
+                      "type": "string"
+                    },
+                    "sriov-network-vlan-1": {
+                      "type": "string"
+                    },
+                    "sriov-network-vlan-2": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "nodeClusterName",
+                "oCloudSiteId",
+                "policyTemplateParameters",
+                "clusterInstanceParameters"
+              ],
+              "type": "object"
+            },
+            "templates": {
+              "clusterInstanceDefaults": "clustertemplate-sample.v1.0.0-clusterinstance-defaults",
+              "hwTemplate": "sample-hwtemplate-v1",
+              "policyTemplateDefaults": "clustertemplate-sample.v1.0.0-policytemplate-defaults",
+              "upgradeDefaults": "upgrade-defaults-v1"
+            },
+            "version": "v1.0.0"
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "HardwarePlugin",
+          "metadata": {
+            "name": "metal3-hwplugin",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "apiRoot": "https://metal3-hardwareplugin-server.oran-o2ims.svc.cluster.local:8443",
+            "authClientConfig": {
+              "type": "ServiceAccount"
+            }
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "HardwareProfile",
+          "metadata": {
+            "name": "hardwareprofile-sample",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "bios": {
+              "attributes": {
+                "SriovGlobalEnable": "Enabled",
+                "SysProfile": "Custom",
+                "WorkloadProfile": "TelcoOptimizedProfile"
+              }
+            }
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "HardwareTemplate",
+          "metadata": {
+            "name": "r740-blue-basic",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "bootInterfaceLabel": "bootable-interface",
+            "hardwarePluginRef": "metal3-hwplugin",
+            "hardwareProvisioningTimeout": "60m",
+            "nodeGroupData": [
+              {
+                "hwProfile": "rh-profile-r740-bios-settings",
+                "name": "controller",
+                "resourceSelector": {
+                  "resourceselector.clcm.openshift.io/server-colour": "blue",
+                  "server-type": "R740"
+                },
+                "role": "master"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "ProvisioningRequest",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oran-o2ims",
+              "app.kubernetes.io/instance": "provisioningrequest-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "provisioningrequest",
+              "app.kubernetes.io/part-of": "oran-o2ims"
+            },
+            "name": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "spec": {
+            "description": "Provisioning request for setting up a Single Node OpenShift (SNO) in the test environment.",
+            "name": "TestEnv-SNO-Provisioning-site-sno-du-1",
+            "templateName": "clustertemplate-sample",
+            "templateParameters": {
+              "clusterInstanceParameters": {
+                "additionalNTPSources": [
+                  "NTP.server1",
+                  "1.1.1.1"
+                ],
+                "apiVIPs": [
+                  "192.0.2.2"
+                ],
+                "baseDomain": "example.com",
+                "clusterName": "site-sno-du-1",
+                "extraAnnotations": {
+                  "AgentClusterInstall": {
+                    "extra-annotation-key": "extra-annotation-value"
+                  }
+                },
+                "extraLabels": {
+                  "AgentClusterInstall": {
+                    "extra-label-key": "extra-label-value"
+                  },
+                  "ManagedCluster": {
+                    "cluster-version": "v4.16",
+                    "clustertemplate-a-policy": "v1"
+                  }
+                },
+                "ingressVIPs": [
+                  "192.0.2.3"
+                ],
+                "machineNetwork": [
+                  {
+                    "cidr": "192.0.2.0/24"
+                  }
+                ],
+                "nodes": [
+                  {
+                    "bootMode": "UEFI",
+                    "extraAnnotations": {
+                      "BareMetalHost": {
+                        "extra-annotation-key": "extra-annotation-value"
+                      }
+                    },
+                    "extraLabels": {
+                      "BareMetalHost": {
+                        "extra-label-key": "extra-label-value"
+                      }
+                    },
+                    "hostName": "node1.baseDomain.com",
+                    "nodeLabels": {
+                      "node-role.kubernetes.io/infra": "",
+                      "node-role.kubernetes.io/master": ""
+                    },
+                    "nodeNetwork": {
+                      "config": {
+                        "dns-resolver": {
+                          "config": {
+                            "server": [
+                              "192.0.2.22"
+                            ]
+                          }
+                        },
+                        "interfaces": [
+                          {
+                            "ipv4": {
+                              "address": [
+                                {
+                                  "ip": "192.0.2.10",
+                                  "prefix-length": 24
+                                },
+                                {
+                                  "ip": "192.0.2.11",
+                                  "prefix-length": 24
+                                },
+                                {
+                                  "ip": "192.0.2.12",
+                                  "prefix-length": 24
+                                }
+                              ],
+                              "dhcp": false,
+                              "enabled": true
+                            },
+                            "ipv6": {
+                              "address": [
+                                {
+                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:601",
+                                  "prefix-length": 64
+                                },
+                                {
+                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:602",
+                                  "prefix-length": 64
+                                },
+                                {
+                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:603",
+                                  "prefix-length": 64
+                                }
+                              ],
+                              "dhcp": false,
+                              "enabled": true
+                            },
+                            "name": "eno1",
+                            "type": "ethernet"
+                          },
+                          {
+                            "ipv6": {
+                              "address": [
+                                {
+                                  "ip": "2620:52:0:1302::100"
+                                }
+                              ],
+                              "enabled": true,
+                              "link-aggregation": {
+                                "mode": "balance-rr",
+                                "options": {
+                                  "miimon": "140"
+                                },
+                                "slaves": [
+                                  "eth0",
+                                  "eth1"
+                                ]
+                              },
+                              "prefix-length": 64
+                            },
+                            "name": "bond99",
+                            "state": "up",
+                            "type": "bond"
+                          }
+                        ],
+                        "routes": {
+                          "config": [
+                            {
+                              "destination": "0.0.0.0/0",
+                              "next-hop-address": "192.0.2.254",
+                              "next-hop-interface": "eno1",
+                              "table-id": 254
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ],
+                "serviceNetwork": [
+                  {
+                    "cidr": "233.252.0.0/24"
+                  }
+                ],
+                "sshPublicKey": "ssh-rsa"
+              },
+              "nodeClusterName": "site-sno-du-1",
+              "oCloudSiteId": "local-west-12345",
+              "policyTemplateParameters": {
+                "sriov-network-vlan-1": "114",
+                "sriov-network-vlan-2": "111"
+              }
+            },
+            "templateVersion": "v1.0.0"
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "ocloud.openshift.io/v1alpha1",
+          "kind": "Inventory",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oran-o2ims",
+              "app.kubernetes.io/instance": "inventory-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "inventory",
+              "app.kubernetes.io/part-of": "oran-o2ims"
+            },
+            "name": "default",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "caBundleName": "o2ims-custom-ca-certs",
+            "cloudID": "b7dcb3ff-583d-42d9-abb5-f484386fc688",
+            "ingress": {
+              "tls": {
+                "secretName": "oran-o2ims-tls-certificate"
+              }
+            },
+            "smo": {
+              "oauth": {
+                "clientSecretName": "oauth-client-secrets",
+                "groupsClaim": "roles",
+                "scopes": [
+                  "openid",
+                  "profile",
+                  "role:ocloud-manager"
+                ],
+                "tokenEndpoint": "/protocol/openid-connect/token",
+                "url": "https://oauth.example.com:8443/realms/oran",
+                "usernameClaim": "preferred_username"
+              },
+              "registrationEndpoint": "/smo/v1/registration",
+              "tls": {
+                "secretName": "oran-o2ims-tls-certificate"
+              },
+              "url": "https://smo.example.com"
+            }
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "plugins.clcm.openshift.io/v1alpha1",
+          "kind": "AllocatedNode",
+          "metadata": {
+            "name": "91c70863-8a83-422a-ab7a-a75f744d5210",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "groupName": "controller",
+            "hardwarePluginRef": "metal3-hwplugin",
+            "hwMgrNodeId": "r740xserver1",
+            "hwMgrNodeNs": "r740-pool",
+            "hwProfile": "rh-profile-r740-bios-settings",
+            "nodeAllocationRequest": "metal3-b12f3e77848a4002bf40"
+          },
+          "status": {
+            "bmc": {
+              "address": "idrac-virtualmedia+https://127.0.0.1/redfish/v1/Systems/System.Embedded.1",
+              "credentialsName": "bmc-secret-r740xserver1"
+            },
+            "conditions": [
+              {
+                "lastTransitionTime": "2025-07-16T12:57:12Z",
+                "message": "Provisioned",
+                "reason": "Completed",
+                "status": "True",
+                "type": "Provisioned"
+              }
+            ],
+            "hwProfile": "rh-profile-r740-bios-settings",
+            "interfaces": [
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:19",
+                "name": "ens1f0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1a",
+                "name": "ens3f1np1"
+              },
+              {
+                "label": "bootable-interface",
+                "macAddress": "c3:f7:f5:b2:4d:1b",
+                "name": "eno1np0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1c",
+                "name": "ens5f3"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1d",
+                "name": "ens5f1"
+              },
+              {
+                "label": "data-interface",
+                "macAddress": "c3:f7:f5:b2:4d:1e",
+                "name": "eno2np1"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1f",
+                "name": "ens7f0np0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:20",
+                "name": "ens7f1np1"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:21",
+                "name": "ens1f1"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:22",
+                "name": "ens5f2"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:23",
+                "name": "ens5f0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:24",
+                "name": "ens3f0np0"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "plugins.clcm.openshift.io/v1alpha1",
+          "kind": "NodeAllocationRequest",
+          "metadata": {
+            "name": "metal3-b12f3e77848a4002bf40",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "bootInterfaceLabel": "bootable-interface",
+            "clusterId": "cluster1",
+            "configTransactionId": 1,
+            "hardwarePluginRef": "metal3-hwplugin",
+            "nodeGroup": [
+              {
+                "nodeGroupData": {
+                  "hwProfile": "rh-profile-r740-bios-settings",
+                  "name": "controller",
+                  "resourceSelector": {
+                    "resourceselector.clcm.openshift.io/server-colour": "blue",
+                    "server-type": "R740"
+                  },
+                  "role": "master"
+                },
+                "size": 1
+              }
+            ],
+            "site": "ottawa"
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2025-07-16T12:57:12Z",
+                "message": "Created",
+                "reason": "Completed",
+                "status": "True",
+                "type": "Provisioned"
+              }
+            ],
+            "hwMgrPlugin": {
+              "observedGeneration": 1
+            },
+            "observedConfigTransactionId": 0,
+            "properties": {
+              "nodeNames": [
+                "91c70863-8a83-422a-ab7a-a75f744d5210"
+              ]
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    containerImage: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator@sha256:cdd64de0298fa499bd4b001f3a273ec0f57da8f29d2ea07825e4719aa8063bec
+    description: The O-Cloud Manager operator provides an implementation of the O-RAN O2 IMS API on top of OpenShift and ACM.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    provider: Red Hat
+    repository: https://github.com/openshift-kni/oran-o2ims
+    support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+  name: o-cloud-manager.v4.20.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: AllocatedNode is the schema for an allocated node
+        displayName: Allocated Node
+        kind: AllocatedNode
+        name: allocatednodes.plugins.clcm.openshift.io
+        resources:
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: Extensions
+            path: extensions
+          - description: GroupName
+            displayName: Group Name
+            path: groupName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HardwarePluginRef is the identifier for the HardwarePlugin instance.
+            displayName: Hardware Plugin Reference
+            path: hardwarePluginRef
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HwMgrNodeId is the node identifier from the hardware manager.
+            displayName: Hardware Manager Node ID
+            path: hwMgrNodeId
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HwMgrNodeNs is the node namespace from the hardware manager.
+            displayName: Hardware Manager Node Namespace
+            path: hwMgrNodeNs
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HwProfile
+            displayName: Hardware Profile
+            path: hwProfile
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: NodeAllocationRequest
+            displayName: Node Allocation Request
+            path: nodeAllocationRequest
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - displayName: BMC
+            path: bmc
+          - description: |-
+              Conditions represent the observations of the AllocatedNodeStatus's current state.
+              Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+            displayName: Conditions
+            path: conditions
+          - displayName: Hostname
+            path: hostname
+          - displayName: Hw Profile
+            path: hwProfile
+          - displayName: Interfaces
+            path: interfaces
+        version: v1alpha1
+      - description: ClusterTemplate is the Schema for the clustertemplates API
+        displayName: Cluster Template
+        kind: ClusterTemplate
+        name: clustertemplates.clcm.openshift.io
+        resources:
+          - kind: ConfigMap
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: Characteristics defines a List of key/value pairs describing characteristics associated with the template.
+            displayName: Characteristics
+            path: characteristics
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Description defines a Human readable description of the Template.
+            displayName: Description
+            path: description
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Metadata defines a List of key/value pairs describing metadata associated with the template.
+            displayName: Metadata
+            path: metadata
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Name defines a Human readable name of the Template.
+            displayName: Name
+            path: name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Release defines the openshift release version of the template
+            displayName: Release
+            path: release
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: TemplateId defines a Identifier for the O-Cloud Template. This identifier is allocated by the O-Cloud.
+            displayName: TemplateId
+            path: templateId
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              TemplateParameterSchema defines the parameters required for ClusterTemplate.
+              The parameter definitions should follow the OpenAPI V3 schema and
+              explicitly define required fields.
+            displayName: Template Parameter Schema
+            path: templateParameterSchema
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Templates defines the references to the templates required for ClusterTemplate.
+            displayName: Templates
+            path: templates
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Version defines a version or generation of the resource as defined by its provider.
+            displayName: Version
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - displayName: Conditions
+            path: conditions
+        version: v1alpha1
+      - description: HardwarePlugin is the Schema for the hardwareplugins API
+        displayName: Hardware Plugin
+        kind: HardwarePlugin
+        name: hardwareplugins.clcm.openshift.io
+        resources:
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: ApiRoot is the root URL for the Hardware Plugin.
+            displayName: Hardware Plugin API root
+            path: apiRoot
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: AuthClientConfig defines the configurable client attributes required to access the OAuth2 authorization server
+            displayName: SMO OAuth Configuration
+            path: authClientConfig
+          - description: |-
+              BasicAuthSecret represents the name of a secret (in the current namespace) containing the username
+              and password for Basic authentication. The secret is expected to contain 'username' and 'password' keys.
+              This field is required when Type is set to "Basic".
+            displayName: Basic Auth Secret
+            path: authClientConfig.basicAuthSecret
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              OAuthConfig holds the configuration for OAuth2-based authentication, including the authorization server
+              URL, token endpoint, and client credentials. This field is required when Type is set to "OAuth".
+            displayName: OAuth Configuration
+            path: authClientConfig.oauthConfig
+          - description: |-
+              TLSConfig specifies the TLS configuration for secure communication, including the certificate and private
+              key. This field is optional and can be used with any authentication type to enable TLS for the connection.
+            displayName: TLS Configuration
+            path: authClientConfig.tlsConfig
+          - description: Type specifies the authentication type to be used (e.g., ServiceAccount, Basic, or OAuth).
+            displayName: Authentication Type
+            path: authClientConfig.type
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:ServiceAccount
+              - urn:alm:descriptor:com.tectonic.ui:select:Basic
+              - urn:alm:descriptor:com.tectonic.ui:select:OAuth
+          - description: |-
+              CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
+              with any outside HardwarePlugin server that has its TLS certificate signed by a non-public CA certificate.
+              The config map is expected to contain a single file called 'ca-bundle.crt' containing all trusted CA certificates
+              in PEM format.
+            displayName: Custom CA Certificates
+            path: caBundleName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: Conditions describe the state of the UpdateService resource.
+            displayName: Conditions
+            path: conditions
+          - displayName: Observed Generation
+            path: observedGeneration
+        version: v1alpha1
+      - description: HardwareProfile is the Schema for the hardwareprofiles API
+        displayName: Hardware Profile
+        kind: HardwareProfile
+        name: hardwareprofiles.clcm.openshift.io
+        resources:
+          - kind: Service
+            name: policy-engine-service
+            version: v1
+        specDescriptors:
+          - description: Bios defines a set of bios attributes
+            displayName: Bios
+            path: bios
+          - displayName: Attributes
+            path: bios.attributes
+          - description: BIOS firmware information
+            displayName: BIOS Firmware
+            path: biosFirmware
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: BMC firmware information
+            displayName: BMC Firmware
+            path: bmcFirmware
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: Represents the observations of a HardwareProfile's current state
+            displayName: Conditions
+            path: conditions
+          - displayName: Observed Generation
+            path: observedGeneration
+        version: v1alpha1
+      - description: HardwareTemplate is the Schema for the hardwaretemplates API
+        displayName: Hardware Template
+        kind: HardwareTemplate
+        name: hardwaretemplates.clcm.openshift.io
+        resources:
+          - kind: ConfigMap
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: BootInterfaceLabel is the label of the boot interface.
+            displayName: Boot Interface Label
+            path: bootInterfaceLabel
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HardwarePluginRef is the name of the HardwarePlugin.
+            displayName: Hardware Plugin Reference
+            path: hardwarePluginRef
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HardwareProvisioningTimeout defines the timeout duration string for the hardware provisioning.
+            displayName: Hardware Provisioning Timeout
+            path: hardwareProvisioningTimeout
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: NodeGroupData defines a collection of NodeGroupData items
+            displayName: Node Group Data
+            path: nodeGroupData
+        statusDescriptors:
+          - displayName: Conditions
+            path: conditions
+        version: v1alpha1
+      - description: Inventory is the Schema for the Inventory API
+        displayName: O-Cloud Manager Inventory
+        kind: Inventory
+        name: inventories.ocloud.openshift.io
+        resources:
+          - kind: Deployment
+            name: ""
+            version: apps/v1
+        specDescriptors:
+          - description: AlarmServerConfig contains the configuration for the alarm server.
+            displayName: Alarm Server Configuration
+            path: alarmServerConfig
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: ArtifactsServerConfig contains the configuration for the artifacts server.
+            displayName: Artifacts Server Configuration
+            path: artifactsServerConfig
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
+              with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
+              a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+              containing all trusted CA certificates in PEM format.
+            displayName: Custom CA Certificates
+            path: caBundleName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: CloudID is the global cloud ID value used to correlate the SMO inventory record with the deployed cloud instance.
+            displayName: Cloud ID
+            path: cloudID
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: ClusterServerConfig contains the configuration for the resource server.
+            displayName: Cluster Server Configuration
+            path: clusterServerConfig
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Image is the full reference of the container image that contains the binary. This is
+              optional and the default will be the value passed to the `--image` command line flag of
+              the controller manager.
+            displayName: Image
+            path: image
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: IngressConfig defines configuration attributes related to the Ingress endpoint.
+            displayName: Ingress Configuration
+            path: ingress
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              IngressHost defines the FQDN for the IMS endpoints.  By default, it is assumed to be "o2ims.apps.<cluster domain name>".
+              If a different DNS domain is used, then it should be customized here.
+            displayName: Ingress Host
+            path: ingress.ingressHost
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              TLS defines the TLS configuration for the IMS endpoints.  The certificate CN and DNS SAN values must match exactly
+              the value provided by the `IngressHost` value.  If the `IngressHost` value is not provided, then the CN and SAN
+              must match the expected default value.  If the TLS configuration is not provided, then the TLS configuration of
+              the default IngressController will be used.
+            displayName: TLS Configuration
+            path: ingress.tls
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              SecretName specifies the name of a secret (in the current namespace) containing an X.509 certificate and
+              private key. The secret must include 'tls.key' and 'tls.crt' keys. If the certificate is signed by
+              intermediate CA(s), the full certificate chain should be included in the certificate file, with the
+              leaf certificate first and the root CA last. The certificate's Common Name (CN) or Subject Alternative
+              Name (SAN) should align with the service's fully qualified domain name to support both ingress and
+              outgoing client certificate use cases.
+            displayName: TLS Certificate
+            path: ingress.tls.secretName
+          - description: ProvisioningServerConfig contains the configuration for the provisioning server.
+            displayName: Provisioning Server Configuration
+            path: provisioningServerConfig
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: ResourceServerConfig contains the configuration for the resource server.
+            displayName: Resource Server Configuration
+            path: resourceServerConfig
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: SmoConfig defines the configurable attributes to represent the SMO instance
+            displayName: SMO Configuration
+            path: smo
+          - description: OAuthConfig defines the configurable attributes required to access the OAuth2 authorization server
+            displayName: SMO OAuth Configuration
+            path: smo.oauth
+          - description: |-
+              ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+              fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+            displayName: OAuth Client Binding Claim
+            path: smo.oauth.clientBindingClaim
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
+              client-secret values used by the OAuth client.
+            displayName: Client Secret
+            path: smo.oauth.clientSecretName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+              must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+              a nested field in the JSON structure of the JWT object.
+                 i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+            displayName: OAuth Groups Claim
+            path: smo.oauth.groupsClaim
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Scopes represents the OAuth scope values to request when acquiring a token.  Typically, this should be set to
+              "openid" in addition to any other scopes that the SMO specifically requires (e.g., "roles", "groups", etc...) to
+              authorize our requests
+            displayName: OAuth Scopes
+            path: smo.oauth.scopes
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              TokenEndpoint represents the API endpoint used to acquire a token (e.g., /protocol/openid-connect/token) which
+              will be appended to the base URL to form the full URL
+            displayName: OAuth Token Endpoint
+            path: smo.oauth.tokenEndpoint
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: URL represents the base URL of the authorization server. (e.g., https://keycloak.example.com/realms/oran)
+            displayName: OAuth URL
+            path: smo.oauth.url
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: UsernameClaim represents the claim contained within the OAuth JWT token which holds the username
+            displayName: OAuth Username Claim
+            path: smo.oauth.usernameClaim
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: RegistrationEndpoint represents the API endpoint used to register the O-Cloud Manager with the SMO.
+            displayName: Registration API Endpoint
+            path: smo.registrationEndpoint
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              TLSConfig defines the TLS attributes specific to enabling mTLS communication to the SMO and OAuth servers.  If
+              a configuration is provided, then an mTLS connection will be established to the destination; otherwise, a regular
+              TLS connection will be used.
+            displayName: Client TLS Configuration
+            path: smo.tls
+          - description: |-
+              SecretName specifies the name of a secret (in the current namespace) containing an X.509 certificate and
+              private key. The secret must include 'tls.key' and 'tls.crt' keys. If the certificate is signed by
+              intermediate CA(s), the full certificate chain should be included in the certificate file, with the
+              leaf certificate first and the root CA last. The certificate's Common Name (CN) or Subject Alternative
+              Name (SAN) should align with the service's fully qualified domain name to support both ingress and
+              outgoing client certificate use cases.
+            displayName: TLS Certificate
+            path: smo.tls.secretName
+          - description: URL represents the base URL of the SMO instance
+            displayName: SMO URL
+            path: smo.url
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: Stores the local cluster ID used as the local Cloud ID value.
+            displayName: Local Cluster ID
+            path: clusterID
+          - description: |-
+              INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+              Important: Run "make" to regenerate code after modifying this file
+            displayName: Conditions
+            path: conditions
+          - description: |-
+              Stores the ingress host domain resolved at runtime; either from a user override or automatically computed from
+              the default ingress controller.
+            displayName: Resolved Ingress Host Address
+            path: ingressHost
+          - displayName: Deployed Server Configurations
+            path: usedServerConfig
+        version: v1alpha1
+      - description: NodeAllocationRequest is the schema for an allocation request of nodes
+        displayName: Node Allocation Request
+        kind: NodeAllocationRequest
+        name: nodeallocationrequests.plugins.clcm.openshift.io
+        resources:
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: BootInterfaceLabel is the label of the boot interface.
+            displayName: Boot Interface Label
+            path: bootInterfaceLabel
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              ClusterID is the identifier of the O-Cloud that generated this request. The hardware
+              manager may want to use this to tag the nodes in its database, and to generate
+              statistics.
+            displayName: Cluster ID
+            path: clusterId
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Config Transaction Id
+            path: configTransactionId
+          - displayName: Extensions
+            path: extensions
+          - description: HardwarePluginRef is the name of the HardwarePlugin.
+            displayName: Hardware Plugin Reference
+            path: hardwarePluginRef
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Location
+            displayName: Location
+            path: location
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Node Group
+            path: nodeGroup
+          - description: Site
+            displayName: Site
+            path: site
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of an NodeAllocationRequest's state.
+            displayName: Conditions
+            path: conditions
+          - displayName: Hw Mgr Plugin
+            path: hwMgrPlugin
+          - displayName: Observed Config Transaction Id
+            path: observedConfigTransactionId
+          - description: Properties represent the node properties in the pool
+            displayName: Properties
+            path: properties
+          - displayName: Selected Groups
+            path: selectedGroups
+        version: v1alpha1
+      - description: ProvisioningRequest is the Schema for the provisioningrequests API
+        displayName: Provisioning Request
+        kind: ProvisioningRequest
+        name: provisioningrequests.clcm.openshift.io
+        resources:
+          - kind: ClusterInstance
+            name: ""
+            version: siteconfig.open-cluster-management.io/v1alpha1
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: Description specifies a brief description of this provisioning request, providing additional context or details.
+            displayName: Description
+            path: description
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Extensions holds additional custom key-value pairs that can be used to extend the cluster's configuration.
+            displayName: Extensions
+            path: extensions
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Name specifies a human-readable name for this provisioning request, intended for identification and descriptive purposes.
+            displayName: Name
+            path: name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              TemplateName defines the base name of the referenced ClusterTemplate.
+              The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+            displayName: Template Name
+            path: templateName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: TemplateParameters provides the input data that conforms to the OpenAPI v3 schema defined in the referenced ClusterTemplate's spec.templateParameterSchema.
+            displayName: Template Parameters
+            path: templateParameters
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              TemplateVersion defines the version of the referenced ClusterTemplate.
+              The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+            displayName: Template Version
+            path: templateVersion
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - displayName: Conditions
+            path: conditions
+        version: v1alpha1
+  description: |-
+    O-cloud manager operator
+  displayName: o-cloud manager
+  icon:
+    - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - nonResourceURLs:
+                - /hardware-manager/inventory/*
+              verbs:
+                - get
+                - list
+            - nonResourceURLs:
+                - /hardware-manager/provisioning/*
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+            - nonResourceURLs:
+                - /internal/v1/caas-alerts/alertmanager
+              verbs:
+                - create
+                - post
+            - nonResourceURLs:
+                - /o2ims-infrastructureCluster/v1/alarmDictionaries
+              verbs:
+                - get
+                - list
+            - nonResourceURLs:
+                - /o2ims-infrastructureCluster/v1/alarmDictionaries/*
+              verbs:
+                - get
+            - nonResourceURLs:
+                - /o2ims-infrastructureCluster/v1/nodeClusterTypes
+              verbs:
+                - get
+                - list
+            - nonResourceURLs:
+                - /o2ims-infrastructureCluster/v1/nodeClusterTypes/*
+              verbs:
+                - get
+            - nonResourceURLs:
+                - /o2ims-infrastructureCluster/v1/nodeClusters
+              verbs:
+                - get
+                - list
+            - nonResourceURLs:
+                - /o2ims-infrastructureCluster/v1/nodeClusters/*
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - agent-install.openshift.io
+              resources:
+                - agents
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - batch
+              resources:
+                - cronjobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - clustertemplates
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - clustertemplates/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - clustertemplates/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwareplugins
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwareplugins/finalizers
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwareplugins/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwareprofiles
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwareprofiles/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwaretemplates
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - hardwaretemplates/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - nodes
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - nodes/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - provisioningrequests
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - provisioningrequests/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - clcm.openshift.io
+              resources:
+                - provisioningrequests/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - cluster.open-cluster-management.io
+              resources:
+                - managedclusters
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - lcm.openshift.io
+              resources:
+                - imagebasedgroupupgrades
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - lcm.openshift.io
+              resources:
+                - imagebasedgroupupgrades/status
+              verbs:
+                - get
+            - apiGroups:
+                - metal3.io
+              resources:
+                - baremetalhosts
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - metal3.io
+              resources:
+                - firmwareschemas
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - metal3.io
+              resources:
+                - hostfirmwarecomponents
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - metal3.io
+              resources:
+                - hostfirmwaresettings
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - metal3.io
+              resources:
+                - hostupdatepolicies
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - metal3.io
+              resources:
+                - preprovisioningimages
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheusrules
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ocloud.openshift.io
+              resources:
+                - inventories
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ocloud.openshift.io
+              resources:
+                - inventories/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ocloud.openshift.io
+              resources:
+                - inventories/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - ingresscontrollers
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - plugins.clcm.openshift.io
+              resources:
+                - allocatednodes
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - plugins.clcm.openshift.io
+              resources:
+                - allocatednodes/finalizers
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - plugins.clcm.openshift.io
+              resources:
+                - allocatednodes/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - plugins.clcm.openshift.io
+              resources:
+                - nodeallocationrequests
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - plugins.clcm.openshift.io
+              resources:
+                - nodeallocationrequests/finalizers
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - plugins.clcm.openshift.io
+              resources:
+                - nodeallocationrequests/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - policy.open-cluster-management.io
+              resources:
+                - policies
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - siteconfig.open-cluster-management.io
+              resources:
+                - clusterinstances
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+          serviceAccountName: oran-o2ims-controller-manager
+      deployments:
+        - label:
+            app: o-cloud-manager
+            app.kubernetes.io/component: manager
+            app.kubernetes.io/created-by: oran-o2ims
+            app.kubernetes.io/instance: controller-manager
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: deployment
+            app.kubernetes.io/part-of: oran-o2ims
+            control-plane: controller-manager
+          name: oran-o2ims-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app: o-cloud-manager
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - command:
+                      - /usr/bin/oran-o2ims
+                      - start
+                      - controller-manager
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=:6443
+                      - --metrics-tls-cert-dir=/secrets/tls/metrics
+                    env:
+                      - name: IMAGE
+                        value: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator@sha256:cdd64de0298fa499bd4b001f3a273ec0f57da8f29d2ea07825e4719aa8063bec
+                      - name: POSTGRES_IMAGE
+                        value: registry.redhat.io/rhel9/postgresql-16@sha256:4f46bed6bce211be83c110a3452bd3f151a1e8ab150c58f2a02c56e9cc83db98
+                      - name: HWMGR_PLUGIN_NAMESPACE
+                        value: oran-o2ims
+                      - name: DEPLOY_LOOPBACK_HW_PLUGIN
+                        value: "false"
+                      - name: OCLOUD_MANAGER_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: IMAGE_PULL_POLICY
+                        value: IfNotPresent
+                    image: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator@sha256:cdd64de0298fa499bd4b001f3a273ec0f57da8f29d2ea07825e4719aa8063bec
+                    imagePullPolicy: IfNotPresent
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
+                      - containerPort: 6443
+                        name: https
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: cert
+                        readOnly: true
+                      - mountPath: /secrets/tls/metrics
+                        name: metrics-tls
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: oran-o2ims-controller-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - name: cert
+                    secret:
+                      defaultMode: 420
+                      secretName: oran-o2ims-webhook-server-cert
+                  - name: metrics-tls
+                    secret:
+                      defaultMode: 420
+                      secretName: controller-manager-metrics-tls
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: oran-o2ims-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - ORAN
+    - O2IMS
+  links:
+    - name: Oran O2ims
+      url: https://oran-o2ims.domain
+  maintainers:
+    - email: imihai@redhat.com
+      name: IrinaMihai
+  maturity: alpha
+  minKubeVersion: 1.32.0
+  provider:
+    name: Red Hat
+  version: 4.20.0
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: oran-o2ims-controller-manager
+      failurePolicy: Fail
+      generateName: provisioningrequests.clcm.openshift.io
+      rules:
+        - apiGroups:
+            - clcm.openshift.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - provisioningrequests
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-clcm-openshift-io-v1alpha1-provisioningrequest
+  relatedImages:
+    - name: manager
+      image: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator@sha256:cdd64de0298fa499bd4b001f3a273ec0f57da8f29d2ea07825e4719aa8063bec
+    - name: postgres_image
+      image: registry.redhat.io/rhel9/postgresql-16@sha256:4f46bed6bce211be83c110a3452bd3f151a1e8ab150c58f2a02c56e9cc83db98

--- a/test/overlay/ocloud/4.20/00.data/map_images.in.yaml
+++ b/test/overlay/ocloud/4.20/00.data/map_images.in.yaml
@@ -1,0 +1,9 @@
+# Do not modify the manager 'key' value: 'manager'
+---
+- key: manager
+  staging: registry.stage.redhat.io/openshift4/o-cloud-manager-rhel9-operator
+  production: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator
+- key: postgres_image
+  staging: registry.stage.redhat.io/rhel9/postgresql-16
+  production: registry.redhat.io/rhel9/postgresql-16
+

--- a/test/overlay/ocloud/4.20/00.data/oran-o2ims.clusterserviceversion.in.yaml
+++ b/test/overlay/ocloud/4.20/00.data/oran-o2ims.clusterserviceversion.in.yaml
@@ -1,0 +1,2027 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "ClusterTemplate",
+          "metadata": {
+            "name": "clustertemplate-sample.v1.0.0",
+            "namespace": "clustertemplate-a-v4-16-3"
+          },
+          "spec": {
+            "characteristics": {
+              "age": "31"
+            },
+            "description": "nice description",
+            "metadata": {
+              "apple": "23"
+            },
+            "name": "clustertemplate-a",
+            "release": "4.16.3",
+            "templateParameterSchema": {
+              "properties": {
+                "clusterInstanceParameters": {
+                  "description": "clusterInstanceParameters defines the available parameters for cluster installation",
+                  "properties": {
+                    "additionalNTPSources": {
+                      "description": "AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster hosts. They are added to any NTP sources that were configured through other means.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "apiVIPs": {
+                      "description": "APIVIPs are the virtual IPs used to reach the OpenShift cluster's API. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "baseDomain": {
+                      "description": "BaseDomain is the base domain to use for the deployed cluster.",
+                      "type": "string"
+                    },
+                    "clusterName": {
+                      "description": "ClusterName is the name of the cluster.",
+                      "type": "string"
+                    },
+                    "extraAnnotations": {
+                      "additionalProperties": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "description": "Additional cluster-wide annotations to be applied to the rendered templates",
+                      "type": "object"
+                    },
+                    "extraLabels": {
+                      "additionalProperties": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "description": "Additional cluster-wide labels to be applied to the rendered templates",
+                      "type": "object"
+                    },
+                    "ingressVIPs": {
+                      "description": "IngressVIPs are the virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "machineNetwork": {
+                      "description": "MachineNetwork is the list of IP address pools for machines.",
+                      "items": {
+                        "description": "MachineNetworkEntry is a single IP address block for node IP blocks.",
+                        "properties": {
+                          "cidr": {
+                            "description": "CIDR is the IP block address pool for machines within the cluster.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "cidr"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodes": {
+                      "items": {
+                        "description": "NodeSpec",
+                        "properties": {
+                          "extraAnnotations": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "description": "Additional node-level annotations to be applied to the rendered templates",
+                            "type": "object"
+                          },
+                          "extraLabels": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "description": "Additional node-level labels to be applied to the rendered templates",
+                            "type": "object"
+                          },
+                          "hostName": {
+                            "description": "Hostname is the desired hostname for the host",
+                            "type": "string"
+                          },
+                          "nodeLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "NodeLabels allows the specification of custom roles for your nodes in your managed clusters. These are additional roles are not used by any OpenShift Container Platform components, only by the user. When you add a custom role, it can be associated with a custom machine config pool that references a specific configuration for that role. Adding custom labels or roles during installation makes the deployment process more effective and prevents the need for additional reboots after the installation is complete.",
+                            "type": "object"
+                          },
+                          "nodeNetwork": {
+                            "description": "NodeNetwork is a set of configurations pertaining to the network settings for the node.",
+                            "properties": {
+                              "config": {
+                                "description": "yaml that can be processed by nmstate, using custom marshaling/unmarshaling that will allow to populate nmstate config as plain yaml.",
+                                "type": "object",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "hostName"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "serviceNetwork": {
+                      "description": "ServiceNetwork is the list of IP address pools for services.",
+                      "items": {
+                        "description": "ServiceNetworkEntry is a single IP address block for node IP blocks.",
+                        "properties": {
+                          "cidr": {
+                            "description": "CIDR is the IP block address pool for machines within the cluster.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "cidr"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "sshPublicKey": {
+                      "description": "SSHPublicKey is the public Secure Shell (SSH) key to provide access to instances. This key will be added to the host to allow ssh access",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "clusterName",
+                    "nodes"
+                  ],
+                  "type": "object"
+                },
+                "nodeClusterName": {
+                  "type": "string"
+                },
+                "oCloudSiteId": {
+                  "type": "string"
+                },
+                "policyTemplateParameters": {
+                  "description": "policyTemplateParameters defines the available parameters for cluster configuration",
+                  "properties": {
+                    "cpu-isolated": {
+                      "type": "string"
+                    },
+                    "cpu-reserved": {
+                      "type": "string"
+                    },
+                    "hugepages-count": {
+                      "type": "string"
+                    },
+                    "hugepages-default": {
+                      "type": "string"
+                    },
+                    "hugepages-size": {
+                      "type": "string"
+                    },
+                    "install-plan-approval": {
+                      "type": "string"
+                    },
+                    "sriov-network-pfNames-1": {
+                      "type": "string"
+                    },
+                    "sriov-network-pfNames-2": {
+                      "type": "string"
+                    },
+                    "sriov-network-vlan-1": {
+                      "type": "string"
+                    },
+                    "sriov-network-vlan-2": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "nodeClusterName",
+                "oCloudSiteId",
+                "policyTemplateParameters",
+                "clusterInstanceParameters"
+              ],
+              "type": "object"
+            },
+            "templates": {
+              "clusterInstanceDefaults": "clustertemplate-sample.v1.0.0-clusterinstance-defaults",
+              "hwTemplate": "sample-hwtemplate-v1",
+              "policyTemplateDefaults": "clustertemplate-sample.v1.0.0-policytemplate-defaults",
+              "upgradeDefaults": "upgrade-defaults-v1"
+            },
+            "version": "v1.0.0"
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "HardwarePlugin",
+          "metadata": {
+            "name": "metal3-hwplugin",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "apiRoot": "https://metal3-hardwareplugin-server.oran-o2ims.svc.cluster.local:8443",
+            "authClientConfig": {
+              "type": "ServiceAccount"
+            }
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "HardwareProfile",
+          "metadata": {
+            "name": "hardwareprofile-sample",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "bios": {
+              "attributes": {
+                "SriovGlobalEnable": "Enabled",
+                "SysProfile": "Custom",
+                "WorkloadProfile": "TelcoOptimizedProfile"
+              }
+            }
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "HardwareTemplate",
+          "metadata": {
+            "name": "r740-blue-basic",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "bootInterfaceLabel": "bootable-interface",
+            "hardwarePluginRef": "metal3-hwplugin",
+            "hardwareProvisioningTimeout": "60m",
+            "nodeGroupData": [
+              {
+                "hwProfile": "rh-profile-r740-bios-settings",
+                "name": "controller",
+                "resourceSelector": {
+                  "resourceselector.clcm.openshift.io/server-colour": "blue",
+                  "server-type": "R740"
+                },
+                "role": "master"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "clcm.openshift.io/v1alpha1",
+          "kind": "ProvisioningRequest",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oran-o2ims",
+              "app.kubernetes.io/instance": "provisioningrequest-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "provisioningrequest",
+              "app.kubernetes.io/part-of": "oran-o2ims"
+            },
+            "name": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "spec": {
+            "description": "Provisioning request for setting up a Single Node OpenShift (SNO) in the test environment.",
+            "name": "TestEnv-SNO-Provisioning-site-sno-du-1",
+            "templateName": "clustertemplate-sample",
+            "templateParameters": {
+              "clusterInstanceParameters": {
+                "additionalNTPSources": [
+                  "NTP.server1",
+                  "1.1.1.1"
+                ],
+                "apiVIPs": [
+                  "192.0.2.2"
+                ],
+                "baseDomain": "example.com",
+                "clusterName": "site-sno-du-1",
+                "extraAnnotations": {
+                  "AgentClusterInstall": {
+                    "extra-annotation-key": "extra-annotation-value"
+                  }
+                },
+                "extraLabels": {
+                  "AgentClusterInstall": {
+                    "extra-label-key": "extra-label-value"
+                  },
+                  "ManagedCluster": {
+                    "cluster-version": "v4.16",
+                    "clustertemplate-a-policy": "v1"
+                  }
+                },
+                "ingressVIPs": [
+                  "192.0.2.3"
+                ],
+                "machineNetwork": [
+                  {
+                    "cidr": "192.0.2.0/24"
+                  }
+                ],
+                "nodes": [
+                  {
+                    "bootMode": "UEFI",
+                    "extraAnnotations": {
+                      "BareMetalHost": {
+                        "extra-annotation-key": "extra-annotation-value"
+                      }
+                    },
+                    "extraLabels": {
+                      "BareMetalHost": {
+                        "extra-label-key": "extra-label-value"
+                      }
+                    },
+                    "hostName": "node1.baseDomain.com",
+                    "nodeLabels": {
+                      "node-role.kubernetes.io/infra": "",
+                      "node-role.kubernetes.io/master": ""
+                    },
+                    "nodeNetwork": {
+                      "config": {
+                        "dns-resolver": {
+                          "config": {
+                            "server": [
+                              "192.0.2.22"
+                            ]
+                          }
+                        },
+                        "interfaces": [
+                          {
+                            "ipv4": {
+                              "address": [
+                                {
+                                  "ip": "192.0.2.10",
+                                  "prefix-length": 24
+                                },
+                                {
+                                  "ip": "192.0.2.11",
+                                  "prefix-length": 24
+                                },
+                                {
+                                  "ip": "192.0.2.12",
+                                  "prefix-length": 24
+                                }
+                              ],
+                              "dhcp": false,
+                              "enabled": true
+                            },
+                            "ipv6": {
+                              "address": [
+                                {
+                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:601",
+                                  "prefix-length": 64
+                                },
+                                {
+                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:602",
+                                  "prefix-length": 64
+                                },
+                                {
+                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:603",
+                                  "prefix-length": 64
+                                }
+                              ],
+                              "dhcp": false,
+                              "enabled": true
+                            },
+                            "name": "eno1",
+                            "type": "ethernet"
+                          },
+                          {
+                            "ipv6": {
+                              "address": [
+                                {
+                                  "ip": "2620:52:0:1302::100"
+                                }
+                              ],
+                              "enabled": true,
+                              "link-aggregation": {
+                                "mode": "balance-rr",
+                                "options": {
+                                  "miimon": "140"
+                                },
+                                "slaves": [
+                                  "eth0",
+                                  "eth1"
+                                ]
+                              },
+                              "prefix-length": 64
+                            },
+                            "name": "bond99",
+                            "state": "up",
+                            "type": "bond"
+                          }
+                        ],
+                        "routes": {
+                          "config": [
+                            {
+                              "destination": "0.0.0.0/0",
+                              "next-hop-address": "192.0.2.254",
+                              "next-hop-interface": "eno1",
+                              "table-id": 254
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ],
+                "serviceNetwork": [
+                  {
+                    "cidr": "233.252.0.0/24"
+                  }
+                ],
+                "sshPublicKey": "ssh-rsa"
+              },
+              "nodeClusterName": "site-sno-du-1",
+              "oCloudSiteId": "local-west-12345",
+              "policyTemplateParameters": {
+                "sriov-network-vlan-1": "114",
+                "sriov-network-vlan-2": "111"
+              }
+            },
+            "templateVersion": "v1.0.0"
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "ocloud.openshift.io/v1alpha1",
+          "kind": "Inventory",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oran-o2ims",
+              "app.kubernetes.io/instance": "inventory-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "inventory",
+              "app.kubernetes.io/part-of": "oran-o2ims"
+            },
+            "name": "default",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "caBundleName": "o2ims-custom-ca-certs",
+            "cloudID": "b7dcb3ff-583d-42d9-abb5-f484386fc688",
+            "ingress": {
+              "tls": {
+                "secretName": "oran-o2ims-tls-certificate"
+              }
+            },
+            "smo": {
+              "oauth": {
+                "clientSecretName": "oauth-client-secrets",
+                "groupsClaim": "roles",
+                "scopes": [
+                  "openid",
+                  "profile",
+                  "role:ocloud-manager"
+                ],
+                "tokenEndpoint": "/protocol/openid-connect/token",
+                "url": "https://oauth.example.com:8443/realms/oran",
+                "usernameClaim": "preferred_username"
+              },
+              "registrationEndpoint": "/smo/v1/registration",
+              "tls": {
+                "secretName": "oran-o2ims-tls-certificate"
+              },
+              "url": "https://smo.example.com"
+            }
+          },
+          "status": {
+            "conditions": []
+          }
+        },
+        {
+          "apiVersion": "plugins.clcm.openshift.io/v1alpha1",
+          "kind": "AllocatedNode",
+          "metadata": {
+            "name": "91c70863-8a83-422a-ab7a-a75f744d5210",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "groupName": "controller",
+            "hardwarePluginRef": "metal3-hwplugin",
+            "hwMgrNodeId": "r740xserver1",
+            "hwMgrNodeNs": "r740-pool",
+            "hwProfile": "rh-profile-r740-bios-settings",
+            "nodeAllocationRequest": "metal3-b12f3e77848a4002bf40"
+          },
+          "status": {
+            "bmc": {
+              "address": "idrac-virtualmedia+https://127.0.0.1/redfish/v1/Systems/System.Embedded.1",
+              "credentialsName": "bmc-secret-r740xserver1"
+            },
+            "conditions": [
+              {
+                "lastTransitionTime": "2025-07-16T12:57:12Z",
+                "message": "Provisioned",
+                "reason": "Completed",
+                "status": "True",
+                "type": "Provisioned"
+              }
+            ],
+            "hwProfile": "rh-profile-r740-bios-settings",
+            "interfaces": [
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:19",
+                "name": "ens1f0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1a",
+                "name": "ens3f1np1"
+              },
+              {
+                "label": "bootable-interface",
+                "macAddress": "c3:f7:f5:b2:4d:1b",
+                "name": "eno1np0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1c",
+                "name": "ens5f3"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1d",
+                "name": "ens5f1"
+              },
+              {
+                "label": "data-interface",
+                "macAddress": "c3:f7:f5:b2:4d:1e",
+                "name": "eno2np1"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:1f",
+                "name": "ens7f0np0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:20",
+                "name": "ens7f1np1"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:21",
+                "name": "ens1f1"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:22",
+                "name": "ens5f2"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:23",
+                "name": "ens5f0"
+              },
+              {
+                "label": "",
+                "macAddress": "c3:f7:f5:b2:4d:24",
+                "name": "ens3f0np0"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "plugins.clcm.openshift.io/v1alpha1",
+          "kind": "NodeAllocationRequest",
+          "metadata": {
+            "name": "metal3-b12f3e77848a4002bf40",
+            "namespace": "oran-o2ims"
+          },
+          "spec": {
+            "bootInterfaceLabel": "bootable-interface",
+            "clusterId": "cluster1",
+            "configTransactionId": 1,
+            "hardwarePluginRef": "metal3-hwplugin",
+            "nodeGroup": [
+              {
+                "nodeGroupData": {
+                  "hwProfile": "rh-profile-r740-bios-settings",
+                  "name": "controller",
+                  "resourceSelector": {
+                    "resourceselector.clcm.openshift.io/server-colour": "blue",
+                    "server-type": "R740"
+                  },
+                  "role": "master"
+                },
+                "size": 1
+              }
+            ],
+            "site": "ottawa"
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2025-07-16T12:57:12Z",
+                "message": "Created",
+                "reason": "Completed",
+                "status": "True",
+                "type": "Provisioned"
+              }
+            ],
+            "hwMgrPlugin": {
+              "observedGeneration": 1
+            },
+            "observedConfigTransactionId": 0,
+            "properties": {
+              "nodeNames": [
+                "91c70863-8a83-422a-ab7a-a75f744d5210"
+              ]
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    containerImage: quay.io/openshift-kni/oran-o2ims-operator
+    description: The O-Cloud Manager operator provides an implementation of the O-RAN
+      O2 IMS API on top of OpenShift and ACM.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=4.16.0 <4.18'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    provider: Red Hat
+    repository: https://github.com/openshift-kni/oran-o2ims
+    support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+  name: oran-o2ims.v4.18.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: AllocatedNode is the schema for an allocated node
+      displayName: Allocated Node
+      kind: AllocatedNode
+      name: allocatednodes.plugins.clcm.openshift.io
+      resources:
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - displayName: Extensions
+        path: extensions
+      - description: GroupName
+        displayName: Group Name
+        path: groupName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HardwarePluginRef is the identifier for the HardwarePlugin instance.
+        displayName: Hardware Plugin Reference
+        path: hardwarePluginRef
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrNodeId is the node identifier from the hardware manager.
+        displayName: Hardware Manager Node ID
+        path: hwMgrNodeId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrNodeNs is the node namespace from the hardware manager.
+        displayName: Hardware Manager Node Namespace
+        path: hwMgrNodeNs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwProfile
+        displayName: Hardware Profile
+        path: hwProfile
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: NodeAllocationRequest
+        displayName: Node Allocation Request
+        path: nodeAllocationRequest
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: BMC
+        path: bmc
+      - description: |-
+          Conditions represent the observations of the AllocatedNodeStatus's current state.
+          Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+        displayName: Conditions
+        path: conditions
+      - displayName: Hostname
+        path: hostname
+      - displayName: Hw Profile
+        path: hwProfile
+      - displayName: Interfaces
+        path: interfaces
+      version: v1alpha1
+    - description: ClusterTemplate is the Schema for the clustertemplates API
+      displayName: Cluster Template
+      kind: ClusterTemplate
+      name: clustertemplates.clcm.openshift.io
+      resources:
+      - kind: ConfigMap
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Characteristics defines a List of key/value pairs describing
+          characteristics associated with the template.
+        displayName: Characteristics
+        path: characteristics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Description defines a Human readable description of the Template.
+        displayName: Description
+        path: description
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Metadata defines a List of key/value pairs describing metadata
+          associated with the template.
+        displayName: Metadata
+        path: metadata
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name defines a Human readable name of the Template.
+        displayName: Name
+        path: name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Release defines the openshift release version of the template
+        displayName: Release
+        path: release
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: TemplateId defines a Identifier for the O-Cloud Template. This
+          identifier is allocated by the O-Cloud.
+        displayName: TemplateId
+        path: templateId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateParameterSchema defines the parameters required for ClusterTemplate.
+          The parameter definitions should follow the OpenAPI V3 schema and
+          explicitly define required fields.
+        displayName: Template Parameter Schema
+        path: templateParameterSchema
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Templates defines the references to the templates required for
+          ClusterTemplate.
+        displayName: Templates
+        path: templates
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Version defines a version or generation of the resource as defined
+          by its provider.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      version: v1alpha1
+    - description: HardwarePlugin is the Schema for the hardwareplugins API
+      displayName: Hardware Plugin
+      kind: HardwarePlugin
+      name: hardwareplugins.clcm.openshift.io
+      resources:
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: ApiRoot is the root URL for the Hardware Plugin.
+        displayName: Hardware Plugin API root
+        path: apiRoot
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: AuthClientConfig defines the configurable client attributes required
+          to access the OAuth2 authorization server
+        displayName: SMO OAuth Configuration
+        path: authClientConfig
+      - description: |-
+          BasicAuthSecret represents the name of a secret (in the current namespace) containing the username
+          and password for Basic authentication. The secret is expected to contain 'username' and 'password' keys.
+          This field is required when Type is set to "Basic".
+        displayName: Basic Auth Secret
+        path: authClientConfig.basicAuthSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          OAuthConfig holds the configuration for OAuth2-based authentication, including the authorization server
+          URL, token endpoint, and client credentials. This field is required when Type is set to "OAuth".
+        displayName: OAuth Configuration
+        path: authClientConfig.oauthConfig
+      - description: |-
+          TLSConfig specifies the TLS configuration for secure communication, including the certificate and private
+          key. This field is optional and can be used with any authentication type to enable TLS for the connection.
+        displayName: TLS Configuration
+        path: authClientConfig.tlsConfig
+      - description: Type specifies the authentication type to be used (e.g., ServiceAccount,
+          Basic, or OAuth).
+        displayName: Authentication Type
+        path: authClientConfig.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:ServiceAccount
+        - urn:alm:descriptor:com.tectonic.ui:select:Basic
+        - urn:alm:descriptor:com.tectonic.ui:select:OAuth
+      - description: |-
+          CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
+          with any outside HardwarePlugin server that has its TLS certificate signed by a non-public CA certificate.
+          The config map is expected to contain a single file called 'ca-bundle.crt' containing all trusted CA certificates
+          in PEM format.
+        displayName: Custom CA Certificates
+        path: caBundleName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Conditions describe the state of the UpdateService resource.
+        displayName: Conditions
+        path: conditions
+      - displayName: Observed Generation
+        path: observedGeneration
+      version: v1alpha1
+    - description: HardwareProfile is the Schema for the hardwareprofiles API
+      displayName: Hardware Profile
+      kind: HardwareProfile
+      name: hardwareprofiles.clcm.openshift.io
+      resources:
+      - kind: Service
+        name: policy-engine-service
+        version: v1
+      specDescriptors:
+      - description: Bios defines a set of bios attributes
+        displayName: Bios
+        path: bios
+      - displayName: Attributes
+        path: bios.attributes
+      - description: BIOS firmware information
+        displayName: BIOS Firmware
+        path: biosFirmware
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: BMC firmware information
+        displayName: BMC Firmware
+        path: bmcFirmware
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Represents the observations of a HardwareProfile's current state
+        displayName: Conditions
+        path: conditions
+      - displayName: Observed Generation
+        path: observedGeneration
+      version: v1alpha1
+    - description: HardwareTemplate is the Schema for the hardwaretemplates API
+      displayName: Hardware Template
+      kind: HardwareTemplate
+      name: hardwaretemplates.clcm.openshift.io
+      resources:
+      - kind: ConfigMap
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: BootInterfaceLabel is the label of the boot interface.
+        displayName: Boot Interface Label
+        path: bootInterfaceLabel
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HardwarePluginRef is the name of the HardwarePlugin.
+        displayName: Hardware Plugin Reference
+        path: hardwarePluginRef
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HardwareProvisioningTimeout defines the timeout duration string
+          for the hardware provisioning.
+        displayName: Hardware Provisioning Timeout
+        path: hardwareProvisioningTimeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: NodeGroupData defines a collection of NodeGroupData items
+        displayName: Node Group Data
+        path: nodeGroupData
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      version: v1alpha1
+    - description: Inventory is the Schema for the Inventory API
+      displayName: O-Cloud Manager Inventory
+      kind: Inventory
+      name: inventories.ocloud.openshift.io
+      resources:
+      - kind: Deployment
+        name: ""
+        version: apps/v1
+      specDescriptors:
+      - description: AlarmServerConfig contains the configuration for the alarm server.
+        displayName: Alarm Server Configuration
+        path: alarmServerConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ArtifactsServerConfig contains the configuration for the artifacts
+          server.
+        displayName: Artifacts Server Configuration
+        path: artifactsServerConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
+          with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
+          a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+          containing all trusted CA certificates in PEM format.
+        displayName: Custom CA Certificates
+        path: caBundleName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: CloudID is the global cloud ID value used to correlate the SMO
+          inventory record with the deployed cloud instance.
+        displayName: Cloud ID
+        path: cloudID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ClusterServerConfig contains the configuration for the resource
+          server.
+        displayName: Cluster Server Configuration
+        path: clusterServerConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Image is the full reference of the container image that contains the binary. This is
+          optional and the default will be the value passed to the `--image` command line flag of
+          the controller manager.
+        displayName: Image
+        path: image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: IngressConfig defines configuration attributes related to the
+          Ingress endpoint.
+        displayName: Ingress Configuration
+        path: ingress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          IngressHost defines the FQDN for the IMS endpoints.  By default, it is assumed to be "o2ims.apps.<cluster domain name>".
+          If a different DNS domain is used, then it should be customized here.
+        displayName: Ingress Host
+        path: ingress.ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TLS defines the TLS configuration for the IMS endpoints.  The certificate CN and DNS SAN values must match exactly
+          the value provided by the `IngressHost` value.  If the `IngressHost` value is not provided, then the CN and SAN
+          must match the expected default value.  If the TLS configuration is not provided, then the TLS configuration of
+          the default IngressController will be used.
+        displayName: TLS Configuration
+        path: ingress.tls
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          SecretName specifies the name of a secret (in the current namespace) containing an X.509 certificate and
+          private key. The secret must include 'tls.key' and 'tls.crt' keys. If the certificate is signed by
+          intermediate CA(s), the full certificate chain should be included in the certificate file, with the
+          leaf certificate first and the root CA last. The certificate's Common Name (CN) or Subject Alternative
+          Name (SAN) should align with the service's fully qualified domain name to support both ingress and
+          outgoing client certificate use cases.
+        displayName: TLS Certificate
+        path: ingress.tls.secretName
+      - description: ProvisioningServerConfig contains the configuration for the provisioning
+          server.
+        displayName: Provisioning Server Configuration
+        path: provisioningServerConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ResourceServerConfig contains the configuration for the resource
+          server.
+        displayName: Resource Server Configuration
+        path: resourceServerConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SmoConfig defines the configurable attributes to represent the
+          SMO instance
+        displayName: SMO Configuration
+        path: smo
+      - description: OAuthConfig defines the configurable attributes required to access
+          the OAuth2 authorization server
+        displayName: SMO OAuth Configuration
+        path: smo.oauth
+      - description: |-
+          ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+          fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+        displayName: OAuth Client Binding Claim
+        path: smo.oauth.clientBindingClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
+          client-secret values used by the OAuth client.
+        displayName: Client Secret
+        path: smo.oauth.clientSecretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+          must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+          a nested field in the JSON structure of the JWT object.
+             i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+        displayName: OAuth Groups Claim
+        path: smo.oauth.groupsClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Scopes represents the OAuth scope values to request when acquiring a token.  Typically, this should be set to
+          "openid" in addition to any other scopes that the SMO specifically requires (e.g., "roles", "groups", etc...) to
+          authorize our requests
+        displayName: OAuth Scopes
+        path: smo.oauth.scopes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TokenEndpoint represents the API endpoint used to acquire a token (e.g., /protocol/openid-connect/token) which
+          will be appended to the base URL to form the full URL
+        displayName: OAuth Token Endpoint
+        path: smo.oauth.tokenEndpoint
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: URL represents the base URL of the authorization server. (e.g.,
+          https://keycloak.example.com/realms/oran)
+        displayName: OAuth URL
+        path: smo.oauth.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: UsernameClaim represents the claim contained within the OAuth
+          JWT token which holds the username
+        displayName: OAuth Username Claim
+        path: smo.oauth.usernameClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: RegistrationEndpoint represents the API endpoint used to register
+          the O-Cloud Manager with the SMO.
+        displayName: Registration API Endpoint
+        path: smo.registrationEndpoint
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TLSConfig defines the TLS attributes specific to enabling mTLS communication to the SMO and OAuth servers.  If
+          a configuration is provided, then an mTLS connection will be established to the destination; otherwise, a regular
+          TLS connection will be used.
+        displayName: Client TLS Configuration
+        path: smo.tls
+      - description: |-
+          SecretName specifies the name of a secret (in the current namespace) containing an X.509 certificate and
+          private key. The secret must include 'tls.key' and 'tls.crt' keys. If the certificate is signed by
+          intermediate CA(s), the full certificate chain should be included in the certificate file, with the
+          leaf certificate first and the root CA last. The certificate's Common Name (CN) or Subject Alternative
+          Name (SAN) should align with the service's fully qualified domain name to support both ingress and
+          outgoing client certificate use cases.
+        displayName: TLS Certificate
+        path: smo.tls.secretName
+      - description: URL represents the base URL of the SMO instance
+        displayName: SMO URL
+        path: smo.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Stores the local cluster ID used as the local Cloud ID value.
+        displayName: Local Cluster ID
+        path: clusterID
+      - description: |-
+          INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+          Important: Run "make" to regenerate code after modifying this file
+        displayName: Conditions
+        path: conditions
+      - description: |-
+          Stores the ingress host domain resolved at runtime; either from a user override or automatically computed from
+          the default ingress controller.
+        displayName: Resolved Ingress Host Address
+        path: ingressHost
+      - displayName: Deployed Server Configurations
+        path: usedServerConfig
+      version: v1alpha1
+    - description: NodeAllocationRequest is the schema for an allocation request of
+        nodes
+      displayName: Node Allocation Request
+      kind: NodeAllocationRequest
+      name: nodeallocationrequests.plugins.clcm.openshift.io
+      resources:
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: BootInterfaceLabel is the label of the boot interface.
+        displayName: Boot Interface Label
+        path: bootInterfaceLabel
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          ClusterID is the identifier of the O-Cloud that generated this request. The hardware
+          manager may want to use this to tag the nodes in its database, and to generate
+          statistics.
+        displayName: Cluster ID
+        path: clusterId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Config Transaction Id
+        path: configTransactionId
+      - displayName: Extensions
+        path: extensions
+      - description: HardwarePluginRef is the name of the HardwarePlugin.
+        displayName: Hardware Plugin Reference
+        path: hardwarePluginRef
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Location
+        displayName: Location
+        path: location
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Node Group
+        path: nodeGroup
+      - description: Site
+        displayName: Site
+        path: site
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Conditions represent the latest available observations of an
+          NodeAllocationRequest's state.
+        displayName: Conditions
+        path: conditions
+      - displayName: Hw Mgr Plugin
+        path: hwMgrPlugin
+      - displayName: Observed Config Transaction Id
+        path: observedConfigTransactionId
+      - description: Properties represent the node properties in the pool
+        displayName: Properties
+        path: properties
+      - displayName: Selected Groups
+        path: selectedGroups
+      version: v1alpha1
+    - description: ProvisioningRequest is the Schema for the provisioningrequests
+        API
+      displayName: Provisioning Request
+      kind: ProvisioningRequest
+      name: provisioningrequests.clcm.openshift.io
+      resources:
+      - kind: ClusterInstance
+        name: ""
+        version: siteconfig.open-cluster-management.io/v1alpha1
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Description specifies a brief description of this provisioning
+          request, providing additional context or details.
+        displayName: Description
+        path: description
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Extensions holds additional custom key-value pairs that can be
+          used to extend the cluster's configuration.
+        displayName: Extensions
+        path: extensions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name specifies a human-readable name for this provisioning request,
+          intended for identification and descriptive purposes.
+        displayName: Name
+        path: name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateName defines the base name of the referenced ClusterTemplate.
+          The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+        displayName: Template Name
+        path: templateName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: TemplateParameters provides the input data that conforms to the
+          OpenAPI v3 schema defined in the referenced ClusterTemplate's spec.templateParameterSchema.
+        displayName: Template Parameters
+        path: templateParameters
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateVersion defines the version of the referenced ClusterTemplate.
+          The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+        displayName: Template Version
+        path: templateVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      version: v1alpha1
+  description: |
+    # O-Cloud Manager operator
+    The O-Cloud Manager operator provides an implementation of the O-RAN O2 IMS API on top of OpenShift and ACM.
+
+    ## Where to find more information
+    You can find additional guidance in the [oran-o2ims repository](https://github.com/openshift-kni/oran-o2ims).
+  displayName: O-Cloud Manager Operator
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - nonResourceURLs:
+          - /hardware-manager/inventory/*
+          verbs:
+          - get
+          - list
+        - nonResourceURLs:
+          - /hardware-manager/provisioning/*
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+        - nonResourceURLs:
+          - /internal/v1/caas-alerts/alertmanager
+          verbs:
+          - create
+          - post
+        - nonResourceURLs:
+          - /o2ims-infrastructureCluster/v1/alarmDictionaries
+          verbs:
+          - get
+          - list
+        - nonResourceURLs:
+          - /o2ims-infrastructureCluster/v1/alarmDictionaries/*
+          verbs:
+          - get
+        - nonResourceURLs:
+          - /o2ims-infrastructureCluster/v1/nodeClusterTypes
+          verbs:
+          - get
+          - list
+        - nonResourceURLs:
+          - /o2ims-infrastructureCluster/v1/nodeClusterTypes/*
+          verbs:
+          - get
+        - nonResourceURLs:
+          - /o2ims-infrastructureCluster/v1/nodeClusters
+          verbs:
+          - get
+          - list
+        - nonResourceURLs:
+          - /o2ims-infrastructureCluster/v1/nodeClusters/*
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - agent-install.openshift.io
+          resources:
+          - agents
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - clustertemplates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - clustertemplates/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - clustertemplates/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwareplugins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwareplugins/finalizers
+          verbs:
+          - patch
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwareplugins/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwareprofiles
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwareprofiles/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwaretemplates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - hardwaretemplates/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - nodes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - nodes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - provisioningrequests
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - provisioningrequests/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - clcm.openshift.io
+          resources:
+          - provisioningrequests/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lcm.openshift.io
+          resources:
+          - imagebasedgroupupgrades
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lcm.openshift.io
+          resources:
+          - imagebasedgroupupgrades/status
+          verbs:
+          - get
+        - apiGroups:
+          - metal3.io
+          resources:
+          - baremetalhosts
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - metal3.io
+          resources:
+          - firmwareschemas
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - metal3.io
+          resources:
+          - hostfirmwarecomponents
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - metal3.io
+          resources:
+          - hostfirmwaresettings
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - metal3.io
+          resources:
+          - hostupdatepolicies
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - metal3.io
+          resources:
+          - preprovisioningimages
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ocloud.openshift.io
+          resources:
+          - inventories
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ocloud.openshift.io
+          resources:
+          - inventories/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ocloud.openshift.io
+          resources:
+          - inventories/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - plugins.clcm.openshift.io
+          resources:
+          - allocatednodes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - plugins.clcm.openshift.io
+          resources:
+          - allocatednodes/finalizers
+          verbs:
+          - patch
+          - update
+        - apiGroups:
+          - plugins.clcm.openshift.io
+          resources:
+          - allocatednodes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - plugins.clcm.openshift.io
+          resources:
+          - nodeallocationrequests
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - plugins.clcm.openshift.io
+          resources:
+          - nodeallocationrequests/finalizers
+          verbs:
+          - patch
+          - update
+        - apiGroups:
+          - plugins.clcm.openshift.io
+          resources:
+          - nodeallocationrequests/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - policy.open-cluster-management.io
+          resources:
+          - policies
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - siteconfig.open-cluster-management.io
+          resources:
+          - clusterinstances
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: oran-o2ims-controller-manager
+      deployments:
+      - label:
+          app: o-cloud-manager
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: oran-o2ims
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: oran-o2ims
+          control-plane: controller-manager
+        name: oran-o2ims-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app: o-cloud-manager
+                control-plane: controller-manager
+            spec:
+              containers:
+              - command:
+                - /usr/bin/oran-o2ims
+                - start
+                - controller-manager
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=:6443
+                - --metrics-tls-cert-dir=/secrets/tls/metrics
+                env:
+                - name: IMAGE
+                  value: quay.io/openshift-kni/oran-o2ims-operator:4.18.0
+                - name: POSTGRES_IMAGE
+                  value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+                - name: HWMGR_PLUGIN_NAMESPACE
+                  value: oran-o2ims
+                - name: DEPLOY_LOOPBACK_HW_PLUGIN
+                  value: "false"
+                - name: OCLOUD_MANAGER_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: IMAGE_PULL_POLICY
+                  value: IfNotPresent
+                image: quay.io/openshift-kni/oran-o2ims-operator:4.18.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                - containerPort: 6443
+                  name: https
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+                - mountPath: /secrets/tls/metrics
+                  name: metrics-tls
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: oran-o2ims-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: oran-o2ims-webhook-server-cert
+              - name: metrics-tls
+                secret:
+                  defaultMode: 420
+                  secretName: controller-manager-metrics-tls
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: oran-o2ims-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - ORAN
+  - O2IMS
+  links:
+  - name: Oran O2ims
+    url: https://oran-o2ims.domain
+  maintainers:
+  - email: imihai@redhat.com
+    name: IrinaMihai
+  maturity: alpha
+  minKubeVersion: 1.28.0
+  provider:
+    name: Red Hat
+  replaces: oran-o2ims.v0.0.0
+  version: 4.18.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: oran-o2ims-controller-manager
+    failurePolicy: Fail
+    generateName: provisioningrequests.clcm.openshift.io
+    rules:
+    - apiGroups:
+      - clcm.openshift.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - provisioningrequests
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-clcm-openshift-io-v1alpha1-provisioningrequest

--- a/test/overlay/ocloud/4.20/00.data/pin_images.in.yaml
+++ b/test/overlay/ocloud/4.20/00.data/pin_images.in.yaml
@@ -1,0 +1,8 @@
+# Do not modify the manager 'key' value: 'manager'
+---
+- key: manager
+  source: quay.io/openshift-kni/oran-o2ims-operator:4.18.0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-4-20@sha256:cdd64de0298fa499bd4b001f3a273ec0f57da8f29d2ea07825e4719aa8063bec
+- key: postgres_image
+  source: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+  target: registry.redhat.io/rhel9/postgresql-16@sha256:4f46bed6bce211be83c110a3452bd3f151a1e8ab150c58f2a02c56e9cc83db98

--- a/test/overlay/ocloud/4.20/00.data/release.in.yaml
+++ b/test/overlay/ocloud/4.20/00.data/release.in.yaml
@@ -1,0 +1,11 @@
+---
+variables:
+  # PLACEHOLDER_ variables will be substituted by ad-hoc overlay logic
+  containerImage: PLACEHOLDER_CONTAINER_IMAGE
+  description: |
+      O-cloud manager operator
+  display_name: "o-cloud manager"
+  manager_version: "o-cloud-manager.v4.20.0"
+  min_kube_version: "1.32.0"
+  version: "4.20.0"
+

--- a/test/overlay/ocloud/4.20/00.test.sh
+++ b/test/overlay/ocloud/4.20/00.test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Source the common test library
+# shellcheck source=test/overlay/common-test-lib.sh
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../../common-test-lib.sh
+
+# Initialize debug mode from command line argument
+init_debug_mode "${1:-}"
+
+# Run the CSV overlay test for oran-o2ims operator
+run_csv_overlay_test "oran-o2ims" "oran-o2ims operator CSV overlay test" "00.data"

--- a/test/overlay/runner.sh
+++ b/test/overlay/runner.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Test Runner Framework
+# Usage: ./runner.sh <operator> <release> [--debug]
+# Example: ./runner.sh lca 4.20 --debug
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$(readlink -f "${BASH_SOURCE[0]}")")
+
+# Global counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Array to track failed test files
+FAILED_TEST_FILES=()
+
+# Debug flag
+DEBUG_FLAG=""
+
+print_log() {
+    echo "[$SCRIPT_NAME] $1"
+}
+
+# Function to find and run tests for an operator/release
+run_tests_for_operator() {
+    local operator=$1
+    local release=$2
+    local test_path="$operator/$release"
+
+    if [[ ! -d "$test_path" ]]; then
+        print_log "Error: test directory not found: $test_path"
+        return 0
+    fi
+
+    print_log "Running tests for operator: $operator, release: $release"
+
+    # Find all test files
+    mapfile -t test_files < <(find "$test_path" -name "*.test.sh" -type f 2>/dev/null | sort)
+
+    if [[ ${#test_files[@]} -eq 0 ]]; then
+        print_log "Error: no test files found in $test_path"
+        return 0
+    fi
+
+    # Run tests
+    for test_file in "${test_files[@]}"; do
+
+        # Add DEBUG_FLAG if it is set
+        if [[ -n "$DEBUG_FLAG" ]]; then
+            test_cmd=("$test_file" "$DEBUG_FLAG")
+        else
+            test_cmd=("$test_file")
+        fi
+
+        # Run test
+        print_log "Running test command: ${test_cmd[*]}"
+        if "${test_cmd[@]}"; then
+            print_log "Test SUCCESS: $test_file"
+            PASSED_TESTS=$((PASSED_TESTS+1))
+        else
+            print_log "Test FAILURE: $test_file"
+            FAILED_TESTS=$((FAILED_TESTS+1))
+            FAILED_TEST_FILES+=("$test_file")
+        fi
+        TOTAL_TESTS=$((TOTAL_TESTS+1))
+    done
+}
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 <operator> <release> [--debug]"
+    echo "       $0 --help             # Show this help"
+    echo ""
+    echo "Operators: lca, nrop, ocloud, talm"
+    echo "Options:"
+    echo "  --debug    Enable debug output for test operations"
+    echo ""
+    echo "Examples:"
+    echo "  $0 lca 4.20"
+    echo "  $0 lca 4.20 --debug"
+}
+
+# Main execution
+main() {
+    # Change to the directory where this script is located
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+
+    # Parse arguments
+    if [[ $# -eq 0 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+        usage
+        exit 0
+    fi
+
+    # Check for debug flag
+    local operator=""
+    local release=""
+
+    for arg in "$@"; do
+        case $arg in
+            --debug)
+                DEBUG_FLAG="--debug"
+                ;;
+            *)
+                if [[ -z "$operator" ]]; then
+                    operator="$arg"
+                elif [[ -z "$release" ]]; then
+                    release="$arg"
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$operator" ]] || [[ -z "$release" ]]; then
+        echo "[${SCRIPT_NAME}] Error: both operator and release parameters are required"
+        usage
+        exit 1
+    fi
+
+    # Validate operator
+    case $operator in
+        lca|nrop|ocloud|talm)
+            ;;
+        *)
+            echo "[${SCRIPT_NAME}] Error: Invalid operator '$operator'. Must be one of: lca, nrop, ocloud, talm"
+            exit 1
+            ;;
+    esac
+
+    if [[ -n "$DEBUG_FLAG" ]]; then
+        print_log "Debug mode enabled for tests"
+    fi
+
+    run_tests_for_operator "$operator" "$release"
+
+    # Print summary
+    local global_status
+    if [[ $FAILED_TESTS -gt 0 ]]; then
+        global_status="FAILURE"
+    else
+        global_status="SUCCESS"
+    fi
+    print_log "Test summary for $operator/$release: Status=$global_status, Total=$TOTAL_TESTS, Passed=$PASSED_TESTS, Failed=$FAILED_TESTS"
+
+    # List failed test files if any
+    if [[ $FAILED_TESTS -gt 0 ]]; then
+        print_log "Failed test files:"
+        for failed_test in "${FAILED_TEST_FILES[@]}"; do
+            print_log "- $failed_test"
+        done
+    fi
+
+}
+
+# Run main function with all arguments
+main "$@"

--- a/test/overlay/talm/4.20/00.data/cluster-group-upgrades-operator.clusterserviceversion.in.yaml
+++ b/test/overlay/talm/4.20/00.data/cluster-group-upgrades-operator.clusterserviceversion.in.yaml
@@ -1,0 +1,628 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ran.openshift.io/v1alpha1",
+          "kind": "ClusterGroupUpgrade",
+          "metadata": {
+            "name": "ClusterGroupUpgrade-sample"
+          },
+          "spec": {
+            "preCaching": true
+          }
+        }
+      ]
+    capabilities: Basic Install
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  name: cluster-group-upgrades-operator.v4.20.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades
+        API
+      displayName: Cluster Group Upgrade
+      kind: ClusterGroupUpgrade
+      name: clustergroupupgrades.ran.openshift.io
+      resources:
+      - kind: Deployment
+        name: ""
+        version: apps/v1
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - displayName: Actions
+        path: actions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          This field determines whether the cluster would be running a backup prior to the upgrade.
+          Deprecated: Use lcm.openshift.io/ImageBasedGroupUpgrade instead for SNO upgrades with built-in backup/rollback functionality
+        displayName: Backup
+        path: backup
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:bool
+      - description: |-
+          The Batch Timeout Action can be specified to control what happens when a batch times out. The default value is `Continue`.
+          The possible values are:
+            - Continue
+            - Abort
+        displayName: BatchTimeoutAction
+        path: batchTimeoutAction
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Blocking CRs
+        path: blockingCRs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          This field holds a list of expressions or labels that will be used to determine what clusters to include in the operation.
+          The expected format is as follows:
+          clusterLabelSelectors:
+            - matchExpressions:
+                - key: label1
+                  operator: In
+                  values:
+                    - value1a
+                    - value1b
+            - matchLabels:
+                label2: value2
+            - matchExpressions:
+                - key: label3
+                  operator: In
+                  values:
+                    - value3
+              matchLabels:
+                label4: value4
+        displayName: Cluster Label Selectors
+        path: clusterLabelSelectors
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          This field holds a label common to multiple clusters that will be updated.
+          The expected format is as follows:
+          clusterSelector:
+            - label1Name=label1Value
+            - label2Name=label2Value
+          If the value is empty, then the expected format is:
+          clusterSelector:
+            - label1Name
+          All the clusters matching the labels specified in clusterSelector will be included
+          in the update plan.
+          Deprecated: Use ClusterLabelSelectors instead
+        displayName: Cluster Selector
+        path: clusterSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Clusters
+        path: clusters
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          This field determines when the upgrade starts. While false, the upgrade doesn't start. The policies,
+          placement rules and placement bindings are created, but clusters are not added to the placement rule.
+          Once set to true, the clusters start being upgraded, one batch at a time.
+        displayName: Enable
+        path: enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:bool
+      - displayName: Managed Policies
+        path: managedPolicies
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Manifest Work Templates
+        path: manifestWorkTemplates
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          This field determines whether container image pre-caching will be done on all the clusters
+          matching the selector.
+          If required, the pre-caching process starts immediately on all clusters irrespectively of
+          the value of the "enable" flag
+        displayName: PreCaching
+        path: preCaching
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:bool
+      - description: |-
+          This field specifies a reference to a pre-caching config custom resource that contains the additional
+          pre-caching configurations.
+        displayName: PreCachingConfigRef
+        path: preCachingConfigRef
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Remediation Strategy
+        path: remediationStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Backup
+        path: backup
+      - displayName: Clusters
+        path: clusters
+      - displayName: Computed Maximum Concurrency
+        path: computedMaxConcurrency
+      - displayName: Conditions
+        path: conditions
+      - description: Deprecated
+        displayName: Copied Policies
+        path: copiedPolicies
+      - displayName: Managed Policies Compliant Before Upgrade
+        path: managedPoliciesCompliantBeforeUpgrade
+      - displayName: Managed Policies Content
+        path: managedPoliciesContent
+      - description: |-
+          Contains the managed policies (and the namespaces) that have NonCompliant clusters
+          that require updating.
+        displayName: Managed Policies For Upgrade
+        path: managedPoliciesForUpgrade
+      - displayName: Managed Policies Namespace
+        path: managedPoliciesNs
+      - description: |-
+          INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+          Important: Run "make" to regenerate code after modifying this file
+        displayName: Placement Bindings
+        path: placementBindings
+      - displayName: Placement Rules
+        path: placementRules
+      - displayName: Precaching
+        path: precaching
+      - displayName: Remediation Plan
+        path: remediationPlan
+      - displayName: Safe Resource Names
+        path: safeResourceNames
+      - displayName: Status
+        path: status
+      version: v1alpha1
+    - description: ImageBasedGroupUpgrade is the schema for upgrading a group of clusters
+        using IBU
+      displayName: Image-Based Group Upgrade
+      kind: ImageBasedGroupUpgrade
+      name: imagebasedgroupupgrades.lcm.openshift.io
+      resources:
+      - kind: Deployment
+        name: ""
+        version: apps/v1
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - displayName: Cluster Label Selectors
+        path: clusterLabelSelectors
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: IBU Spec
+        path: ibuSpec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Plan
+        path: plan
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      - displayName: Status
+        path: observedGeneration
+      version: v1alpha1
+    - description: PreCachingConfig is the Schema for the precachingconfigs API
+      displayName: Pre-caching Config
+      kind: PreCachingConfig
+      name: precachingconfigs.ran.openshift.io
+      resources:
+      - kind: Namespace
+        name: “”
+        version: v1
+      version: v1alpha1
+  description: cluster-group-upgrades-operator is an operator that facilitates platform
+    upgrades of group of clusters
+  displayName: cluster-group-upgrades-operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAIAAAAP3aGbAAAbp0lEQVR4Xu3dfWhc15nH8StpJGtkOdcSQxSaOhrDkkJpkcIugdJQjcu+saGVloTd/rHF44a+wMJaLoQ2fxTLFJou6RJ5octm2zRjtvtHlwSPU7LsltCMS0IgUCI1YVmXgEdxHaIwtWZkSaOX0cweza0nyrEkz8t9Oc+93w/ByOcG4lia332ec885t6tWq1kAIEG3PgAApiKwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGF21Wk0fA5pWzecrudx2Pt8Y6Ukmu5PJWCrVGAHcQmChTSqnyjMzlcuX9Qu39IyN9YyP96ZSKrxUhOmXgdYRWGhZrVhcTae3Ll3SL+yve3RUxZYKr96pqa6jR/XLQHMILNNtz82pgFC/VotF61bDpSqXoD726k9yM5WqlUr6haapyutQOq2Si7ILrSKwDLWZyWxms6rt2i8anJqlb2pKffL1a55Rf6q16en9/kitUv8L6g+vwkvlr34N2AuBZZyN2dn12dnqwoJ+YR9dtq0+9vGZGa8LFpVWq6dO6aNuILnQJALLIKrbWk2nt+fn9QvNiU1MqNjy6PGcd2m1m5Nc/dPTXocvhCKwTOFWt+VFbKkY3bxwQR/1kjPP1ZdOBzVVBzMRWEZwvX5RH3hVp6gPvH6hRbViUcWoz2m1W+/kZN/UVOf/IwgHAit4rqdVg+qwVLXV9qe9ms+vTE213aK6yJmnUxHMJFfEEVgBq+RyN0+c0EddpWJLZZbqsFqaGNqYnS3PzHTeorqLVjHiCKwgqRJmeXzct1Bw2quD152rHnArm1VR1fxjykD0nTypksvdqTqYj8AK0s1U6oCtLd5x1nDt7Pi7tQBV5VRlbm57bq6l9euBU/8jzlQdBVdEEFiBUT3X2pkz+ijaQsEVEQRWMFRFU0omfWsGI8J5Nsp2xRDjPKxgGDifHQLb8/Orp06pO8Ha9HR114k3CA0qrACoz1Lp+HF9FG6jTwwfKqwAqPJKH4IHNi9cuHnixPL4+GYmo1+DTFRYfqO8CgTPE8OBCstvG9ztg1BdWFg7c6aUTO7MHtZPFoNEVFh+Kx49ynR7sLps+9D0dKtL/2ECKixfbWYypFXg1Ldg/dw51ZivptM8TJSFwPIV/aBRNi9cULFFkygILaF/mG43ltMk9k9PMyVvOCos/2xls/oQzPCHJrE+Ja9fg0mosPyzPD5uwtlSOFiHh4jBUwSWT7bn5pYfeEAfhaliExMDs7OcF2gaWkKfMN0uS+XyZXWD2Tlln/l4k1Bh+aSUTBp+JB72pDrEw5kMGxINQYXlh533NpNWMqlv3M0TJyi1DEFg+WF9dlYfgigb58/fTKXUjUe/AH/REvqB7Tjh0GXbqj3snZrSL8AvVFie28pmSatwUN/Hlb/+aw6rCRCB5blN1ouGy+qpU2RWUGgJvcXZ7WF1+LnnWFzqPyosb9EPhpWqs9hr5T8Cy1v0gyHG6TT+oyX0kOoHi0ND+ihCJDYxcSSX00fhGSosD9EyhF7l8mUm4P1EheUhjmeIgu7RUZvG0C9UWF6p5vOkVRRUFxYosnxDYHmFfjA62HrlGwLLK5wnEx2qlGaboT8ILE+oH1/6wUjh/uQPAssT/PhGDTMA/uApoSc4ri+C7KtXeTOr16iw3MdxfdFEkeUDAst9PDOKpi2WvHuPltB9HNcXTV22fZRjlD1GheUyjmeILPV9Z3GD1wgsl3E8Q5QRWF4jsFzGzGuUMY3lNQLLTZuZDP1glFUILI8RWG6iH4y46sICry/0FIHlGvWTunXpkj6KiKHI8hSB5Rpmr2AxjeUxAss19IOweFDoMRaOuoPj29EwxGfKM1RY7uDMSTQwjeUdAssdnCeDBqaxvENguYDj27Eb01jeIbBcwPNB7EZL6B0CywX0g9iNXdDeIbA6RT+I2xFYHiGwOkV5hdsx7+4R1mF1iuPbcTteB+0RKqyOcHw79sQuaI8QWB2hH8R+eFboBQKrI7/neAbso8K8uwcIrPblcrlB5imwDyosLxBY7cvQD2J/lcuX9SF0jKeEbSoWi8mhoav6MPChI6+8Ekul9FF0gAqrTaq84vB2HIzlo64jsNo0W3+98wpnYGF/LB91HYHVjlwut1BffvVGX59+DbiFeXfXEVjtcMor5dzi4kevAB+qlUpVniO7isBqWT6fv3Rr+dVblvXOyMhHrwMfoshyF4HVMm01wzcpsrA/prHcRWC1TAusVy3rlxRZ2AcPCt1FYLUmm8060+27Pba4uNnfrw0Cyvb8PLugXURgtWbP1e0ly3p0fV0fBeqYxnIRgdWC3dPtGtUYvpBI6KMAu6BdRWC1YM/yquGrhcIVMgu3ocJyEXsJP+T8YNWKxcYtcXturjEBob5+qrv7e0tLt/71PdiW9XoicU+hoF9AtPEuaLdELrBUAO0cE5rPb+fz1cY/t82j7+l4fbrqYJ+2rJfj8d5yWb+ACGMXtFtCHlhOPG3lck4wdXLix2vHjn3h2jV9dC9kFjQDTz99aHpaH0XrQhhYKqFUc6dCyt0D179sWS/pY/sis7Bb7+TkIG/bdUNIAktVT1vZrAopFVW10h37tnY00w/u9rBl/bs+hojqsu2jrMZyg+zAUjXURiajosrFSmpPhZGR+1vfgqMy6yfUWaizr17tTib1UbRI5LIGVU+tTU+XksnlBx7YOH/e67RSXo/F9KEmqBbyT8vlrXhcv4DoYXGDK4QF1mYmczOVKh0/7k9ONVxZW9OHmvMWmYU6dkG7QkxgqahSJdXqqVOdPOlr268OXH51MCezlm1bv4AoYRe0KwQEViOq/Cyp3KUya6xUem94WL+AyGAXtCuMDizV9i+Pj5sQVa/qAy0rWdZnb9x4g707EcY0VucMDSx1L1qbnr554oS6L+nXxFKZ9ZeFAnukI4td0J0zMbCcwmrj/Hn9Qih8tVB4PB6vDAzoFxB2VFidM24d1sbs7NqZM/po0FpdNXpHn7asn9v2Xd6scYWx2AXdIbMqrNV02sC0sur54i5nGp4praihyOqQKYFVKxZVWm1euKBfMIMXSxKcKa1nWO4QJSxu6JApgWVyWikPj47qQy55olSasCxWaUUEy0c7ZERgqbTa2ufoYUN8plLRh9xDexgdVFgdCj6wyjMzJtdWjtHr1z0tgZz2kKeHoVddWCj+5jf6KJoWcGBVcrn1c+f0USM9pA+479ly+U/W1jgYPtz+78c/1ofQtCADy5lo10dN9a1jx/QhD7yr2s9C4bv9/ZRaYVV79119CE0LMrBUMxj4npvmferaNU+7wt2eXl+n1AqropyfeQMFFljVfF7cWvZv+/gszym1Ho/Head0yHx8aanILuh2BRZYqrzSh4z3lc1N/xKr7tly+RPr678cGdEvQLIcixvaFUxgqfLK/CeDt+stl/0sshwly3p0cfGLlvU+HWJYEFhtCyaw1mdn9SEh/C+yHK9a1ifrk/EcXhoCBFbbggmsLbGvPFJF1g+Cq3SeXl+/v1ymQxStWK3Oh+jQJJ8FEFjuvi7Qf48UCq7vhW6e0yFOWNY7xJZMb3fvfOgostoTQGBtZDL6kDQ/C67IcrxlWQ/WJ7bYhCjO75aXLQKrXQEEVghO2LinUHjSgKR41bKSpdLj8TixJYjzQhMCqz0BHOC31NWlD8k0Ua90DPFYPP6dvj5OBDRf4zBI/z96IeB3hRWC8qpBNYbmFDbPlstjpdIzts1jRJO9n0g0bikUWW3wO7Cq+bw+JJZqDJ8x6c1dpfrpWveXyyq2VoaG9MswwE+3txtfz3HUTOv8DqztEAWW8uc3bpwxbOuME1v3LS0xt2Wgn+56Iy8VVhv8Dqzw+c76+qNGnqygmkRnSp4l8oZ4Z2Rk90EN6y+/vLP/P1y3cK/5HVhhmsNq+GGtFuDKrIOp2PpkofBF1m0Z4JuLi7t/+97q6vq5c6Xjx1fTaWKrSX4HVij1lssvx+PGZpZVXwDx4OLiuGX9cmSEWflAvJFIaO8Pbzxi3rxwgdhqEoHlDpVZRj003NO79VXy95fLPxgaYnrLT5WBga8VCvqoZS3ce2/ja2KrGQSWa+4pFF4bHjY/BkqW9b2lpWSppPrE13w5RhVP1Gq7Z68aXo/FtBFi62AElps+duOGiMxyqA7lC9euHbcsCi5P/WJ4+NlyWR+te2mfTbVObK1NT9c46u+j/A6s7mRSHwoXWZll7Sq4Jpjh8oBKqy/duKGP3nLwTomN8+dLyeSG2LOYvEBguU9cZjneqs9wjZTLX7ast2kV3XBwWln1WcWD7xC1UmntzJnl8fFQPl5vg++BdfSoPhRGKrOu9Peb/NzwAC9Z1ufqreLj8TjJ1bY7ppXjvSY2S2zPz988cWI1naZD9DuwesbH9aGQ6ltfN3ytw8FK9TVcJFcbKgMD6m+smbSy9pp338/OxFYyKffwS1f4fVqDukUUo7TNTf3sPlGr7TfnKs7DlvWNY8fGVlYGd20xwW7vJxJ/WygcPDm122Px+FMt/nj0Tk4ezmS6otGsaPwOLEXdJUSfONqG7/b3P72+ro9KpirHr4yMpGKx0evX9WtRtRWPf79Wa/Ubrf4mL+tjd9Zl24PZbCyV0i+EXQCBpVpxia/M6dAvhoe/fuNG+E6rsi3rIcv6m3vv/Uylkvjo1pPoUFH1k76+75faPI2sqdZxL4dOnx6I2DPEAAJrM5NZPXVKH42A94aH/+rGjT0XEIbDffV6IVLhtTI09B/VattR5fjtyEjbf109Y2Oq1IrCw3dHAIFVzedLx4/ro9GgbsWPlMvanrJQsuvh9Ui9bfzYjRu9LU7TmO/tY8f+8dq1l/ThdvxmdPTjHUySqPbwcCbTOzWlXwijAAJLWR4f347wm46ese0nOroly+MUXw+PjqriS25+qfvNlUTiQqHwfLns4vfv58eOffbaNX20Rf1nz8YFvk29VcEE1sbs7NqZM/polFypP0sKcXt4MKf++tzQ0CcGBh6IxUY++MDYCFMhpXr5XKXywuKiR6Xxv4yOfqmDCquh7+TJgdnZcD89DCawotwVNqhPwt93dT2/tqZfiKqH6kGmqrDDlYpKsf719bZndjqxMjT0+4GB12OxX3/wwRvlcvMLFNrmVmBZ9SmtI7lciDMrmMBSVqamti5d0kejJ6xPD1306XqQOVnmjKi+sufWess2qjN1q1i8+271xXal4qzbVNl0pd7l+RBPt3OlJWzoHh0dzGbDukI7sMCq5HI3T5zQRyNp2bb/rlTyqN2A+TqcdL9dl22rOiuUmeX31pyGWCrVfeuGGXF3lUovWtaPjD//D1LUSqWbqdR2GN/KE1hgKVF4qNG8RwqFedt+SB9G+LlbXjnCmlmBtYSOCG7TuaM36g8QmdWKiPssy7tQCV9vGGSFZVFk7eXBQuG38bhprzuER/7swPOwOhS+OivgCsuiyNrf+4nE1woFJuPDzd1HhHsKU50VcIWlHM5k9CHU3VMovGhZz4+MMBkfYg/u9TYdd6k6a2VqKhyH/wUfWLFUqndyUh/FLZ9fXFQd4pM2b4kIoYfrL4jTRz2gmhjVG4Ygs4IPLGVnPwGfx/2pn+mvl0rztv2Yl/Md8N+3fDzHdXt+fm16Wh+VxojA6k4mmX2/o7tKpafK5TxLH8LiPsv6lMezV5rNCxekv4Mn+En3hogf4dCSd0ZGvunZXlz44/mRkc8HsVnyyCuvyD2q1KDAqubzKrNqETt3pRPEllyqTH5RH/NJl23b+bzQDdJGtIQOGsNW/dHiovqhf2NkhCZRnH9LJPQhv6iaYDWd1keFMKjCcnCKQ3tUtfXM8nJoXs8Tbk/a9teD7iQGL16UeEipcYFVKxZVY8hS0vYs2/Z3NzeJLZMF2AzuJrQxNKgldKi/wcFovyqyE86TxEXWbZnqPst6wYy1KUIbQ+MCy6q/Hfrwc8/po2ias27rav05lNxXT4ePuoX81/CwPytFm7F16VIll9NHzWZcS9gQzdcXeuH9ROKfVlfpE4Ol0uq14eGPNff+et90j46qxlAfNZi5gaXcTKUql9t4LS72sBWPv3j48D+38hZ1uMXMtHKobqZPTm9odGDVisWdwzFYTeoqp+By90VVOIDqyn+WSNzj/Sbn9sgqsowOLKueWaVkktWkXnjt2LF/delVoNjPowMDP6zVzJm32pOgIsv0wFK25+Z2NpqTWd6gVfTOjxKJR0wtrHYTVGQJCCyLzPLFytDQ//T0kFyuMLwNvJ2UIktGYFlklo9Ucr0yMPCf16/TLbbBtqwfCCmsdotNTByRsMRBTGBZvMrQd6pbfCORyBYKzNA36Unb/srmpuEzVvu56803zT9G2cSFo/uJpVIsKPWT+uB99tq1p8rlq5b1v4nE0yxD3d9j8Xi+vkNQaFopGxIOK5dUYTlUnbVzQDW9YUBU2XUlkfjvlZWfLy0x26UawG9Lrqp2EzH1Li+wLOazjBHl8HrYsr7h/QtvfGZ+VygysCwyyzwqvN4bHn49FntpYeFVywrrN0Y1xf+QSPzF9vbg0pJ+Tb5Dp08PmH2GstTAssgss60MDeUHB3+9ufnC4uK7lvWufl0Su34mjKqnxlZWQplTDT1jY3eZ/dZVwYFl1U9VXpmaYu+O+VT9tXj33W9WKlfW1n5V7x8Nv8/Y9WLqkZGRVCw2ev26fjm8ji4tmXxIluzAsthvKNnvRkeL1erb3d2/W15WKaYiLMCJsPvq/6iE+uO+vmTYK6kDGP6KCvGBZdUza216mrNoQkMFmfp1oVq91r2z7OalhQWnHHMl0Zzz71UB9XD9v/KZSuVwpZII4u01Zuo/e9bkVyuEIbAcKrM2zp/XRxFeTpupj+7l45y43bTeyUmTj/wNT2Apm5nM6qlT+iiAphm+RydUgWXx6BDo2JDBmSBpa04zesbH7Xy+Z2xMvwBAvrAFltJ19Ohdc3N9J0/qFwA0oVYs6kPGCGFgOQ5nMoefe66Ll10BLdo2eO1oaANL6Uunj+Ry3fWn1wBCIMyBZdWntFR72Ds5qV8AIFDIA8uqT2kNZrO0h0AIhG1ZwwFUZ76aTrOJBziYydsJw19hNTjt4aHTp/ULAHYxNq2sSFVYDZVcTpVaVbZrAHth4ahZYqkUM/HAngx/qh7FwLJuzcQPXrzITDywW3cyqQ+ZJKKB5eidmrLzeUotoIHAMhqlFrAbgSWAU2rxABGI8dYcQXiAiIizr141uciiwvqIWCqlSq3+s2f1C0AEdNm2yWllEVh7is/MqPtMbGJCvwCEmsmvn3AQWHtT95kjudzgxYuGL0sBXNRrfGAxh3UHtWJxfXZ2/dw5/QIQOoZPYFkEVpOq+fza9PTWpUv6BSAsVDNh5/P6qGFoCZuibjuD2eyRV17htHiEVe/UlD5kHiqslm1mMqra4sU8CJm73nyzx+xFWBaB1R5nYmtjdpbYQjiI6ActWsL2dB09Gp+Z4d08CI3+6Wl9yEhUWJ1iPh7Sddm2Kq9MPrevgQqrU435eBaaQqjeqSkRaWVRYbmrksuVZ2Yqly/rFwCDmb/8qoEKy02xVOpILke1BUH6Tp6UklYWFZZ3qLYggqDyyqLC8g7VFszXf/asoLSyqLD8QbUFAwl6ONhAheWHRrXFui2Y43AmIyutLCos/1XzeVVtbV64oF8AfNQ7OTmYzeqjxiOwgqFiayOTYXMPAiGxGXQQWEGqFYtb2awquDhFHn7aeRZk/Fl9e2IOK0jqFteXTqt73eDFizxMhD/6z54VmlYWFZZRtufm1mdnmd6Cd4ROXTUQWMZRfeJmJqOSiz4R7uoZGzuSy0mcumogsMy1lc1uZDKcAwFXyJ1o343AMp3zPFHVXBRcaJtKK1VbmX+g6B0RWGJQcKE9oUkri8ASh4ILLQlTWlkEllyVXG6n4MpmWXqK/YRgll1DYMnmLD3dzGZpFaGJTUwMZrNhSiuLwAoN1So6k1zb8/P6NUTPodOnB2Zn9VH5CKywUcm1PjurwotJrmjqsm0VVX3ptH4hFAis0Nqem3MmuUiu6OgZG1NtoKwz+VpCYIUfyRUR/WfPxmdm9NFwIbAiRCXXzvR8Nss8V8jEJiZUGxiatQsHILCiyJmhV+HFqc3Sddm2qqoOCXlvc+cIrEhzVkVs5XKs55Lo0OnTKq1CtnDhYAQW/qCSy+3UXLkcDaP5+k6eVFEV4sn1/RBY0KmGUcUWZZeZIhtVDgILB9mem/tDeLGSPlBdtt2XTvdPT0c2qhwEFprlJJf6lal6P3WPjqqcUmkVqbmq/RBYaMfOVNfcnJNftI1eUCVV79TUoXRa7vnrXiCw0CmVXE547XzBhH3Heicn+6amwrq3pkMEFtxUKxY/DK+5OdbWN8mpp3pTKfUrrd8BCCx4iPw6WM/YmOr4VD1F39ckAgu+cia/tvN5J8IiOP8Vm5joGR9XxZQKKYqpVhFYCJJTgu0UX8Xizvy9+m3oZsFUGaUSKjY+vvMrlVRnCCwYp5rPV+slWLUeZ06oSanFVAGl6iYnobqTyShsSPYTgQUxnCBT+VWZm2v81qo/pvQ5zlTRpFLJCSb1W5VNzte0eF4jsBAeTi3W+O1WLvfhtVu0f6dBVUN7LiLv3dXEEUmBI7AAiNGtDwCAqQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiPH/MiKT6dBv5iYAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - action.open-cluster-management.io
+          resources:
+          - managedclusteractions
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps.open-cluster-management.io
+          resources:
+          - placementrules
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - lcm.openshift.io
+          resources:
+          - imagebasedgroupupgrades
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lcm.openshift.io
+          resources:
+          - imagebasedgroupupgrades/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - lcm.openshift.io
+          resources:
+          - imagebasedgroupupgrades/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy.open-cluster-management.io
+          resources:
+          - placementbindings
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy.open-cluster-management.io
+          resources:
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - clustergroupupgrades
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - clustergroupupgrades/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - clustergroupupgrades/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - precachingconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - precachingconfigs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - precachingconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - view.open-cluster-management.io
+          resources:
+          - managedclusterviews
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - work.open-cluster-management.io
+          resources:
+          - manifestworkreplicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - work.open-cluster-management.io
+          resources:
+          - manifestworks
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: cluster-group-upgrades-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: talm
+          app.kubernetes.io/name: talm-operator
+          control-plane: controller-manager
+        name: cluster-group-upgrades-controller-manager-v2
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: talm
+              app.kubernetes.io/name: talm-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: talm
+                app.kubernetes.io/name: talm-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                - --metrics-bind-address=:6443
+                - --metrics-tls-cert-dir=/secrets/tls/metrics
+                command:
+                - /manager
+                env:
+                - name: PRECACHE_IMG
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.20.0
+                - name: RECOVERY_IMG
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.20.0
+                - name: INSECURE_GRAPH_CALL
+                  value: "false"
+                - name: AZTP_IMG
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-aztp:4.20.0
+                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.20.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 6443
+                  name: https
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                volumeMounts:
+                - mountPath: /secrets/tls/metrics
+                  name: metrics-tls
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cluster-group-upgrades-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: metrics-tls
+                secret:
+                  defaultMode: 420
+                  secretName: controller-manager-metrics-tls
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: cluster-group-upgrades-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - acm lifecyclemanagement upgrades cluster
+  links:
+  - name: Cluster Group Upgrades Operator
+    url: https://cluster-group-upgrades-operator.domain
+  maturity: alpha
+  provider:
+    name: Red Hat
+  replaces: cluster-group-upgrades-operator.v4.14.0
+  version: 4.20.0

--- a/test/overlay/talm/4.20/00.data/expected/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/test/overlay/talm/4.20/00.data/expected/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -1,0 +1,636 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ran.openshift.io/v1alpha1",
+          "kind": "ClusterGroupUpgrade",
+          "metadata": {
+            "name": "ClusterGroupUpgrade-sample"
+          },
+          "spec": {
+            "preCaching": true
+          }
+        }
+      ]
+    capabilities: Basic Install
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    containerImage: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator@sha256:bfcff2bacd2dec985215ec6ef1a3a59cb77dfc5f4093eeffb38030398cc4b32a
+  name: topology-aware-lifecycle-manager.v4.20.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades API
+        displayName: Cluster Group Upgrade
+        kind: ClusterGroupUpgrade
+        name: clustergroupupgrades.ran.openshift.io
+        resources:
+          - kind: Deployment
+            name: ""
+            version: apps/v1
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: Actions
+            path: actions
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              This field determines whether the cluster would be running a backup prior to the upgrade.
+              Deprecated: Use lcm.openshift.io/ImageBasedGroupUpgrade instead for SNO upgrades with built-in backup/rollback functionality
+            displayName: Backup
+            path: backup
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:bool
+          - description: |-
+              The Batch Timeout Action can be specified to control what happens when a batch times out. The default value is `Continue`.
+              The possible values are:
+                - Continue
+                - Abort
+            displayName: BatchTimeoutAction
+            path: batchTimeoutAction
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Blocking CRs
+            path: blockingCRs
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              This field holds a list of expressions or labels that will be used to determine what clusters to include in the operation.
+              The expected format is as follows:
+              clusterLabelSelectors:
+                - matchExpressions:
+                    - key: label1
+                      operator: In
+                      values:
+                        - value1a
+                        - value1b
+                - matchLabels:
+                    label2: value2
+                - matchExpressions:
+                    - key: label3
+                      operator: In
+                      values:
+                        - value3
+                  matchLabels:
+                    label4: value4
+            displayName: Cluster Label Selectors
+            path: clusterLabelSelectors
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              This field holds a label common to multiple clusters that will be updated.
+              The expected format is as follows:
+              clusterSelector:
+                - label1Name=label1Value
+                - label2Name=label2Value
+              If the value is empty, then the expected format is:
+              clusterSelector:
+                - label1Name
+              All the clusters matching the labels specified in clusterSelector will be included
+              in the update plan.
+              Deprecated: Use ClusterLabelSelectors instead
+            displayName: Cluster Selector
+            path: clusterSelector
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Clusters
+            path: clusters
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              This field determines when the upgrade starts. While false, the upgrade doesn't start. The policies,
+              placement rules and placement bindings are created, but clusters are not added to the placement rule.
+              Once set to true, the clusters start being upgraded, one batch at a time.
+            displayName: Enable
+            path: enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:bool
+          - displayName: Managed Policies
+            path: managedPolicies
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Manifest Work Templates
+            path: manifestWorkTemplates
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              This field determines whether container image pre-caching will be done on all the clusters
+              matching the selector.
+              If required, the pre-caching process starts immediately on all clusters irrespectively of
+              the value of the "enable" flag
+            displayName: PreCaching
+            path: preCaching
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:bool
+          - description: |-
+              This field specifies a reference to a pre-caching config custom resource that contains the additional
+              pre-caching configurations.
+            displayName: PreCachingConfigRef
+            path: preCachingConfigRef
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Remediation Strategy
+            path: remediationStrategy
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - displayName: Backup
+            path: backup
+          - displayName: Clusters
+            path: clusters
+          - displayName: Computed Maximum Concurrency
+            path: computedMaxConcurrency
+          - displayName: Conditions
+            path: conditions
+          - description: Deprecated
+            displayName: Copied Policies
+            path: copiedPolicies
+          - displayName: Managed Policies Compliant Before Upgrade
+            path: managedPoliciesCompliantBeforeUpgrade
+          - displayName: Managed Policies Content
+            path: managedPoliciesContent
+          - description: |-
+              Contains the managed policies (and the namespaces) that have NonCompliant clusters
+              that require updating.
+            displayName: Managed Policies For Upgrade
+            path: managedPoliciesForUpgrade
+          - displayName: Managed Policies Namespace
+            path: managedPoliciesNs
+          - description: |-
+              INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+              Important: Run "make" to regenerate code after modifying this file
+            displayName: Placement Bindings
+            path: placementBindings
+          - displayName: Placement Rules
+            path: placementRules
+          - displayName: Precaching
+            path: precaching
+          - displayName: Remediation Plan
+            path: remediationPlan
+          - displayName: Safe Resource Names
+            path: safeResourceNames
+          - displayName: Status
+            path: status
+        version: v1alpha1
+      - description: ImageBasedGroupUpgrade is the schema for upgrading a group of clusters using IBU
+        displayName: Image-Based Group Upgrade
+        kind: ImageBasedGroupUpgrade
+        name: imagebasedgroupupgrades.lcm.openshift.io
+        resources:
+          - kind: Deployment
+            name: ""
+            version: apps/v1
+          - kind: Namespace
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: Cluster Label Selectors
+            path: clusterLabelSelectors
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: IBU Spec
+            path: ibuSpec
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Plan
+            path: plan
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - displayName: Conditions
+            path: conditions
+          - displayName: Status
+            path: observedGeneration
+        version: v1alpha1
+      - description: PreCachingConfig is the Schema for the precachingconfigs API
+        displayName: Pre-caching Config
+        kind: PreCachingConfig
+        name: precachingconfigs.ran.openshift.io
+        resources:
+          - kind: Namespace
+            name: “”
+            version: v1
+        version: v1alpha1
+  description: |-
+    Topology Aware Lifecycle Manager is an operator that facilitates
+          platform and operator upgrades of group of clusters
+  displayName: Topology Aware Lifecycle Manager
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAIAAAAP3aGbAAAbp0lEQVR4Xu3dfWhc15nH8StpJGtkOdcSQxSaOhrDkkJpkcIugdJQjcu+saGVloTd/rHF44a+wMJaLoQ2fxTLFJou6RJ5octm2zRjtvtHlwSPU7LsltCMS0IgUCI1YVmXgEdxHaIwtWZkSaOX0cweza0nyrEkz8t9Oc+93w/ByOcG4lia332ec885t6tWq1kAIEG3PgAApiKwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGF21Wk0fA5pWzecrudx2Pt8Y6Ukmu5PJWCrVGAHcQmChTSqnyjMzlcuX9Qu39IyN9YyP96ZSKrxUhOmXgdYRWGhZrVhcTae3Ll3SL+yve3RUxZYKr96pqa6jR/XLQHMILNNtz82pgFC/VotF61bDpSqXoD726k9yM5WqlUr6haapyutQOq2Si7ILrSKwDLWZyWxms6rt2i8anJqlb2pKffL1a55Rf6q16en9/kitUv8L6g+vwkvlr34N2AuBZZyN2dn12dnqwoJ+YR9dtq0+9vGZGa8LFpVWq6dO6aNuILnQJALLIKrbWk2nt+fn9QvNiU1MqNjy6PGcd2m1m5Nc/dPTXocvhCKwTOFWt+VFbKkY3bxwQR/1kjPP1ZdOBzVVBzMRWEZwvX5RH3hVp6gPvH6hRbViUcWoz2m1W+/kZN/UVOf/IwgHAit4rqdVg+qwVLXV9qe9ms+vTE213aK6yJmnUxHMJFfEEVgBq+RyN0+c0EddpWJLZZbqsFqaGNqYnS3PzHTeorqLVjHiCKwgqRJmeXzct1Bw2quD152rHnArm1VR1fxjykD0nTypksvdqTqYj8AK0s1U6oCtLd5x1nDt7Pi7tQBV5VRlbm57bq6l9euBU/8jzlQdBVdEEFiBUT3X2pkz+ijaQsEVEQRWMFRFU0omfWsGI8J5Nsp2xRDjPKxgGDifHQLb8/Orp06pO8Ha9HR114k3CA0qrACoz1Lp+HF9FG6jTwwfKqwAqPJKH4IHNi9cuHnixPL4+GYmo1+DTFRYfqO8CgTPE8OBCstvG9ztg1BdWFg7c6aUTO7MHtZPFoNEVFh+Kx49ynR7sLps+9D0dKtL/2ECKixfbWYypFXg1Ldg/dw51ZivptM8TJSFwPIV/aBRNi9cULFFkygILaF/mG43ltMk9k9PMyVvOCos/2xls/oQzPCHJrE+Ja9fg0mosPyzPD5uwtlSOFiHh4jBUwSWT7bn5pYfeEAfhaliExMDs7OcF2gaWkKfMN0uS+XyZXWD2Tlln/l4k1Bh+aSUTBp+JB72pDrEw5kMGxINQYXlh533NpNWMqlv3M0TJyi1DEFg+WF9dlYfgigb58/fTKXUjUe/AH/REvqB7Tjh0GXbqj3snZrSL8AvVFie28pmSatwUN/Hlb/+aw6rCRCB5blN1ouGy+qpU2RWUGgJvcXZ7WF1+LnnWFzqPyosb9EPhpWqs9hr5T8Cy1v0gyHG6TT+oyX0kOoHi0ND+ihCJDYxcSSX00fhGSosD9EyhF7l8mUm4P1EheUhjmeIgu7RUZvG0C9UWF6p5vOkVRRUFxYosnxDYHmFfjA62HrlGwLLK5wnEx2qlGaboT8ILE+oH1/6wUjh/uQPAssT/PhGDTMA/uApoSc4ri+C7KtXeTOr16iw3MdxfdFEkeUDAst9PDOKpi2WvHuPltB9HNcXTV22fZRjlD1GheUyjmeILPV9Z3GD1wgsl3E8Q5QRWF4jsFzGzGuUMY3lNQLLTZuZDP1glFUILI8RWG6iH4y46sICry/0FIHlGvWTunXpkj6KiKHI8hSB5Rpmr2AxjeUxAss19IOweFDoMRaOuoPj29EwxGfKM1RY7uDMSTQwjeUdAssdnCeDBqaxvENguYDj27Eb01jeIbBcwPNB7EZL6B0CywX0g9iNXdDeIbA6RT+I2xFYHiGwOkV5hdsx7+4R1mF1iuPbcTteB+0RKqyOcHw79sQuaI8QWB2hH8R+eFboBQKrI7/neAbso8K8uwcIrPblcrlB5imwDyosLxBY7cvQD2J/lcuX9SF0jKeEbSoWi8mhoav6MPChI6+8Ekul9FF0gAqrTaq84vB2HIzlo64jsNo0W3+98wpnYGF/LB91HYHVjlwut1BffvVGX59+DbiFeXfXEVjtcMor5dzi4kevAB+qlUpVniO7isBqWT6fv3Rr+dVblvXOyMhHrwMfoshyF4HVMm01wzcpsrA/prHcRWC1TAusVy3rlxRZ2AcPCt1FYLUmm8060+27Pba4uNnfrw0Cyvb8PLugXURgtWbP1e0ly3p0fV0fBeqYxnIRgdWC3dPtGtUYvpBI6KMAu6BdRWC1YM/yquGrhcIVMgu3ocJyEXsJP+T8YNWKxcYtcXturjEBob5+qrv7e0tLt/71PdiW9XoicU+hoF9AtPEuaLdELrBUAO0cE5rPb+fz1cY/t82j7+l4fbrqYJ+2rJfj8d5yWb+ACGMXtFtCHlhOPG3lck4wdXLix2vHjn3h2jV9dC9kFjQDTz99aHpaH0XrQhhYKqFUc6dCyt0D179sWS/pY/sis7Bb7+TkIG/bdUNIAktVT1vZrAopFVW10h37tnY00w/u9rBl/bs+hojqsu2jrMZyg+zAUjXURiajosrFSmpPhZGR+1vfgqMy6yfUWaizr17tTib1UbRI5LIGVU+tTU+XksnlBx7YOH/e67RSXo/F9KEmqBbyT8vlrXhcv4DoYXGDK4QF1mYmczOVKh0/7k9ONVxZW9OHmvMWmYU6dkG7QkxgqahSJdXqqVOdPOlr268OXH51MCezlm1bv4AoYRe0KwQEViOq/Cyp3KUya6xUem94WL+AyGAXtCuMDizV9i+Pj5sQVa/qAy0rWdZnb9x4g707EcY0VucMDSx1L1qbnr554oS6L+nXxFKZ9ZeFAnukI4td0J0zMbCcwmrj/Hn9Qih8tVB4PB6vDAzoFxB2VFidM24d1sbs7NqZM/po0FpdNXpHn7asn9v2Xd6scYWx2AXdIbMqrNV02sC0sur54i5nGp4praihyOqQKYFVKxZVWm1euKBfMIMXSxKcKa1nWO4QJSxu6JApgWVyWikPj47qQy55olSasCxWaUUEy0c7ZERgqbTa2ufoYUN8plLRh9xDexgdVFgdCj6wyjMzJtdWjtHr1z0tgZz2kKeHoVddWCj+5jf6KJoWcGBVcrn1c+f0USM9pA+479ly+U/W1jgYPtz+78c/1ofQtCADy5lo10dN9a1jx/QhD7yr2s9C4bv9/ZRaYVV79119CE0LMrBUMxj4npvmferaNU+7wt2eXl+n1AqropyfeQMFFljVfF7cWvZv+/gszym1Ho/Head0yHx8aanILuh2BRZYqrzSh4z3lc1N/xKr7tly+RPr678cGdEvQLIcixvaFUxgqfLK/CeDt+stl/0sshwly3p0cfGLlvU+HWJYEFhtCyaw1mdn9SEh/C+yHK9a1ifrk/EcXhoCBFbbggmsLbGvPFJF1g+Cq3SeXl+/v1ymQxStWK3Oh+jQJJ8FEFjuvi7Qf48UCq7vhW6e0yFOWNY7xJZMb3fvfOgostoTQGBtZDL6kDQ/C67IcrxlWQ/WJ7bYhCjO75aXLQKrXQEEVghO2LinUHjSgKR41bKSpdLj8TixJYjzQhMCqz0BHOC31NWlD8k0Ua90DPFYPP6dvj5OBDRf4zBI/z96IeB3hRWC8qpBNYbmFDbPlstjpdIzts1jRJO9n0g0bikUWW3wO7Cq+bw+JJZqDJ8x6c1dpfrpWveXyyq2VoaG9MswwE+3txtfz3HUTOv8DqztEAWW8uc3bpwxbOuME1v3LS0xt2Wgn+56Iy8VVhv8Dqzw+c76+qNGnqygmkRnSp4l8oZ4Z2Rk90EN6y+/vLP/P1y3cK/5HVhhmsNq+GGtFuDKrIOp2PpkofBF1m0Z4JuLi7t/+97q6vq5c6Xjx1fTaWKrSX4HVij1lssvx+PGZpZVXwDx4OLiuGX9cmSEWflAvJFIaO8Pbzxi3rxwgdhqEoHlDpVZRj003NO79VXy95fLPxgaYnrLT5WBga8VCvqoZS3ce2/ja2KrGQSWa+4pFF4bHjY/BkqW9b2lpWSppPrE13w5RhVP1Gq7Z68aXo/FtBFi62AElps+duOGiMxyqA7lC9euHbcsCi5P/WJ4+NlyWR+te2mfTbVObK1NT9c46u+j/A6s7mRSHwoXWZll7Sq4Jpjh8oBKqy/duKGP3nLwTomN8+dLyeSG2LOYvEBguU9cZjneqs9wjZTLX7ast2kV3XBwWln1WcWD7xC1UmntzJnl8fFQPl5vg++BdfSoPhRGKrOu9Peb/NzwAC9Z1ufqreLj8TjJ1bY7ppXjvSY2S2zPz988cWI1naZD9DuwesbH9aGQ6ltfN3ytw8FK9TVcJFcbKgMD6m+smbSy9pp338/OxFYyKffwS1f4fVqDukUUo7TNTf3sPlGr7TfnKs7DlvWNY8fGVlYGd20xwW7vJxJ/WygcPDm122Px+FMt/nj0Tk4ezmS6otGsaPwOLEXdJUSfONqG7/b3P72+ro9KpirHr4yMpGKx0evX9WtRtRWPf79Wa/Ubrf4mL+tjd9Zl24PZbCyV0i+EXQCBpVpxia/M6dAvhoe/fuNG+E6rsi3rIcv6m3vv/Uylkvjo1pPoUFH1k76+75faPI2sqdZxL4dOnx6I2DPEAAJrM5NZPXVKH42A94aH/+rGjT0XEIbDffV6IVLhtTI09B/VattR5fjtyEjbf109Y2Oq1IrCw3dHAIFVzedLx4/ro9GgbsWPlMvanrJQsuvh9Ui9bfzYjRu9LU7TmO/tY8f+8dq1l/ThdvxmdPTjHUySqPbwcCbTOzWlXwijAAJLWR4f347wm46ese0nOroly+MUXw+PjqriS25+qfvNlUTiQqHwfLns4vfv58eOffbaNX20Rf1nz8YFvk29VcEE1sbs7NqZM/polFypP0sKcXt4MKf++tzQ0CcGBh6IxUY++MDYCFMhpXr5XKXywuKiR6Xxv4yOfqmDCquh7+TJgdnZcD89DCawotwVNqhPwt93dT2/tqZfiKqH6kGmqrDDlYpKsf719bZndjqxMjT0+4GB12OxX3/wwRvlcvMLFNrmVmBZ9SmtI7lciDMrmMBSVqamti5d0kejJ6xPD1306XqQOVnmjKi+sufWess2qjN1q1i8+271xXal4qzbVNl0pd7l+RBPt3OlJWzoHh0dzGbDukI7sMCq5HI3T5zQRyNp2bb/rlTyqN2A+TqcdL9dl22rOiuUmeX31pyGWCrVfeuGGXF3lUovWtaPjD//D1LUSqWbqdR2GN/KE1hgKVF4qNG8RwqFedt+SB9G+LlbXjnCmlmBtYSOCG7TuaM36g8QmdWKiPssy7tQCV9vGGSFZVFk7eXBQuG38bhprzuER/7swPOwOhS+OivgCsuiyNrf+4nE1woFJuPDzd1HhHsKU50VcIWlHM5k9CHU3VMovGhZz4+MMBkfYg/u9TYdd6k6a2VqKhyH/wUfWLFUqndyUh/FLZ9fXFQd4pM2b4kIoYfrL4jTRz2gmhjVG4Ygs4IPLGVnPwGfx/2pn+mvl0rztv2Yl/Md8N+3fDzHdXt+fm16Wh+VxojA6k4mmX2/o7tKpafK5TxLH8LiPsv6lMezV5rNCxekv4Mn+En3hogf4dCSd0ZGvunZXlz44/mRkc8HsVnyyCuvyD2q1KDAqubzKrNqETt3pRPEllyqTH5RH/NJl23b+bzQDdJGtIQOGsNW/dHiovqhf2NkhCZRnH9LJPQhv6iaYDWd1keFMKjCcnCKQ3tUtfXM8nJoXs8Tbk/a9teD7iQGL16UeEipcYFVKxZVY8hS0vYs2/Z3NzeJLZMF2AzuJrQxNKgldKi/wcFovyqyE86TxEXWbZnqPst6wYy1KUIbQ+MCy6q/Hfrwc8/po2ias27rav05lNxXT4ePuoX81/CwPytFm7F16VIll9NHzWZcS9gQzdcXeuH9ROKfVlfpE4Ol0uq14eGPNff+et90j46qxlAfNZi5gaXcTKUql9t4LS72sBWPv3j48D+38hZ1uMXMtHKobqZPTm9odGDVisWdwzFYTeoqp+By90VVOIDqyn+WSNzj/Sbn9sgqsowOLKueWaVkktWkXnjt2LF/delVoNjPowMDP6zVzJm32pOgIsv0wFK25+Z2NpqTWd6gVfTOjxKJR0wtrHYTVGQJCCyLzPLFytDQ//T0kFyuMLwNvJ2UIktGYFlklo9Ucr0yMPCf16/TLbbBtqwfCCmsdotNTByRsMRBTGBZvMrQd6pbfCORyBYKzNA36Unb/srmpuEzVvu56803zT9G2cSFo/uJpVIsKPWT+uB99tq1p8rlq5b1v4nE0yxD3d9j8Xi+vkNQaFopGxIOK5dUYTlUnbVzQDW9YUBU2XUlkfjvlZWfLy0x26UawG9Lrqp2EzH1Li+wLOazjBHl8HrYsr7h/QtvfGZ+VygysCwyyzwqvN4bHn49FntpYeFVywrrN0Y1xf+QSPzF9vbg0pJ+Tb5Dp08PmH2GstTAssgss60MDeUHB3+9ufnC4uK7lvWufl0Su34mjKqnxlZWQplTDT1jY3eZ/dZVwYFl1U9VXpmaYu+O+VT9tXj33W9WKlfW1n5V7x8Nv8/Y9WLqkZGRVCw2ev26fjm8ji4tmXxIluzAsthvKNnvRkeL1erb3d2/W15WKaYiLMCJsPvq/6iE+uO+vmTYK6kDGP6KCvGBZdUza216mrNoQkMFmfp1oVq91r2z7OalhQWnHHMl0Zzz71UB9XD9v/KZSuVwpZII4u01Zuo/e9bkVyuEIbAcKrM2zp/XRxFeTpupj+7l45y43bTeyUmTj/wNT2Apm5nM6qlT+iiAphm+RydUgWXx6BDo2JDBmSBpa04zesbH7Xy+Z2xMvwBAvrAFltJ19Ohdc3N9J0/qFwA0oVYs6kPGCGFgOQ5nMoefe66Ll10BLdo2eO1oaANL6Uunj+Ry3fWn1wBCIMyBZdWntFR72Ds5qV8AIFDIA8uqT2kNZrO0h0AIhG1ZwwFUZ76aTrOJBziYydsJw19hNTjt4aHTp/ULAHYxNq2sSFVYDZVcTpVaVbZrAHth4ahZYqkUM/HAngx/qh7FwLJuzcQPXrzITDywW3cyqQ+ZJKKB5eidmrLzeUotoIHAMhqlFrAbgSWAU2rxABGI8dYcQXiAiIizr141uciiwvqIWCqlSq3+s2f1C0AEdNm2yWllEVh7is/MqPtMbGJCvwCEmsmvn3AQWHtT95kjudzgxYuGL0sBXNRrfGAxh3UHtWJxfXZ2/dw5/QIQOoZPYFkEVpOq+fza9PTWpUv6BSAsVDNh5/P6qGFoCZuibjuD2eyRV17htHiEVe/UlD5kHiqslm1mMqra4sU8CJm73nyzx+xFWBaB1R5nYmtjdpbYQjiI6ActWsL2dB09Gp+Z4d08CI3+6Wl9yEhUWJ1iPh7Sddm2Kq9MPrevgQqrU435eBaaQqjeqSkRaWVRYbmrksuVZ2Yqly/rFwCDmb/8qoEKy02xVOpILke1BUH6Tp6UklYWFZZ3qLYggqDyyqLC8g7VFszXf/asoLSyqLD8QbUFAwl6ONhAheWHRrXFui2Y43AmIyutLCos/1XzeVVtbV64oF8AfNQ7OTmYzeqjxiOwgqFiayOTYXMPAiGxGXQQWEGqFYtb2awquDhFHn7aeRZk/Fl9e2IOK0jqFteXTqt73eDFizxMhD/6z54VmlYWFZZRtufm1mdnmd6Cd4ROXTUQWMZRfeJmJqOSiz4R7uoZGzuSy0mcumogsMy1lc1uZDKcAwFXyJ1o343AMp3zPFHVXBRcaJtKK1VbmX+g6B0RWGJQcKE9oUkri8ASh4ILLQlTWlkEllyVXG6n4MpmWXqK/YRgll1DYMnmLD3dzGZpFaGJTUwMZrNhSiuLwAoN1So6k1zb8/P6NUTPodOnB2Zn9VH5CKywUcm1PjurwotJrmjqsm0VVX3ptH4hFAis0Nqem3MmuUiu6OgZG1NtoKwz+VpCYIUfyRUR/WfPxmdm9NFwIbAiRCXXzvR8Nss8V8jEJiZUGxiatQsHILCiyJmhV+HFqc3Sddm2qqoOCXlvc+cIrEhzVkVs5XKs55Lo0OnTKq1CtnDhYAQW/qCSy+3UXLkcDaP5+k6eVFEV4sn1/RBY0KmGUcUWZZeZIhtVDgILB9mem/tDeLGSPlBdtt2XTvdPT0c2qhwEFprlJJf6lal6P3WPjqqcUmkVqbmq/RBYaMfOVNfcnJNftI1eUCVV79TUoXRa7vnrXiCw0CmVXE547XzBhH3Heicn+6amwrq3pkMEFtxUKxY/DK+5OdbWN8mpp3pTKfUrrd8BCCx4iPw6WM/YmOr4VD1F39ckAgu+cia/tvN5J8IiOP8Vm5joGR9XxZQKKYqpVhFYCJJTgu0UX8Xizvy9+m3oZsFUGaUSKjY+vvMrlVRnCCwYp5rPV+slWLUeZ06oSanFVAGl6iYnobqTyShsSPYTgQUxnCBT+VWZm2v81qo/pvQ5zlTRpFLJCSb1W5VNzte0eF4jsBAeTi3W+O1WLvfhtVu0f6dBVUN7LiLv3dXEEUmBI7AAiNGtDwCAqQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiPH/MiKT6dBv5iYAAAAASUVORK5CYII=
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - action.open-cluster-management.io
+              resources:
+                - managedclusteractions
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps.open-cluster-management.io
+              resources:
+                - placementrules
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - cluster.open-cluster-management.io
+              resources:
+                - managedclusters
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - cluster.open-cluster-management.io
+              resources:
+                - managedclusters/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - lcm.openshift.io
+              resources:
+                - imagebasedgroupupgrades
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - lcm.openshift.io
+              resources:
+                - imagebasedgroupupgrades/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - lcm.openshift.io
+              resources:
+                - imagebasedgroupupgrades/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheusrules
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - policy.open-cluster-management.io
+              resources:
+                - placementbindings
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - policy.open-cluster-management.io
+              resources:
+                - policies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ran.openshift.io
+              resources:
+                - clustergroupupgrades
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ran.openshift.io
+              resources:
+                - clustergroupupgrades/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ran.openshift.io
+              resources:
+                - clustergroupupgrades/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - ran.openshift.io
+              resources:
+                - precachingconfigs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ran.openshift.io
+              resources:
+                - precachingconfigs/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ran.openshift.io
+              resources:
+                - precachingconfigs/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - view.open-cluster-management.io
+              resources:
+                - managedclusterviews
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - work.open-cluster-management.io
+              resources:
+                - manifestworkreplicasets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - work.open-cluster-management.io
+              resources:
+                - manifestworks
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+          serviceAccountName: cluster-group-upgrades-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/component: talm
+            app.kubernetes.io/name: talm-operator
+            control-plane: controller-manager
+          name: cluster-group-upgrades-controller-manager-v2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: talm
+                app.kubernetes.io/name: talm-operator
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: talm
+                  app.kubernetes.io/name: talm-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --leader-elect
+                      - --metrics-bind-address=:6443
+                      - --metrics-tls-cert-dir=/secrets/tls/metrics
+                    command:
+                      - /manager
+                    env:
+                      - name: PRECACHE_IMG
+                        value: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-precache-rhel9@sha256:a09bdc86b7df18f5bb797f228228123474d7fad39d1566e4e33dcbd10f9e9d32
+                      - name: RECOVERY_IMG
+                        value: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9@sha256:9ed52e744e9123b3050b68e37dc9b5a861e332ed73526f88395ec0a434cd9706
+                      - name: INSECURE_GRAPH_CALL
+                        value: "false"
+                      - name: AZTP_IMG
+                        value: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-aztp-rhel9@sha256:05781c0c43c36272e32be018dd814a82de522049dde5e5d10b2aa240924bc4be
+                    image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator@sha256:bfcff2bacd2dec985215ec6ef1a3a59cb77dfc5f4093eeffb38030398cc4b32a
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 6443
+                        name: https
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 20Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                    volumeMounts:
+                      - mountPath: /secrets/tls/metrics
+                        name: metrics-tls
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: cluster-group-upgrades-controller-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - name: metrics-tls
+                    secret:
+                      defaultMode: 420
+                      secretName: controller-manager-metrics-tls
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: cluster-group-upgrades-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - acm lifecyclemanagement upgrades cluster
+  links:
+    - name: Cluster Group Upgrades Operator
+      url: https://cluster-group-upgrades-operator.domain
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 4.20.0
+  relatedImages:
+    - name: manager
+      image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator@sha256:bfcff2bacd2dec985215ec6ef1a3a59cb77dfc5f4093eeffb38030398cc4b32a
+    - name: recovery_img
+      image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9@sha256:9ed52e744e9123b3050b68e37dc9b5a861e332ed73526f88395ec0a434cd9706
+    - name: precache_img
+      image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-precache-rhel9@sha256:a09bdc86b7df18f5bb797f228228123474d7fad39d1566e4e33dcbd10f9e9d32
+    - name: aztp_img
+      image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-aztp-rhel9@sha256:05781c0c43c36272e32be018dd814a82de522049dde5e5d10b2aa240924bc4be
+  minKubeVersion: 1.32.0

--- a/test/overlay/talm/4.20/00.data/map_images.in.yaml
+++ b/test/overlay/talm/4.20/00.data/map_images.in.yaml
@@ -1,0 +1,20 @@
+# Manager
+- key: manager
+  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator
+  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator
+#
+# Aztp
+- key: aztp_img
+  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-aztp-rhel9
+  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-aztp-rhel9
+#
+# Precache
+- key: precache_img
+  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-precache-rhel9
+  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-precache-rhel9
+#
+# Recovery
+- key: recovery_img
+  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+#

--- a/test/overlay/talm/4.20/00.data/pin_images.in.yaml
+++ b/test/overlay/talm/4.20/00.data/pin_images.in.yaml
@@ -1,0 +1,20 @@
+# Manager
+- key: manager
+  source: quay.io/openshift-kni/cluster-group-upgrades-operator:4.20.0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-4-20@sha256:bfcff2bacd2dec985215ec6ef1a3a59cb77dfc5f4093eeffb38030398cc4b32a
+#
+# Aztp
+- key: aztp_img
+  source: quay.io/openshift-kni/cluster-group-upgrades-operator-aztp:4.20.0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-aztp-4-20@sha256:05781c0c43c36272e32be018dd814a82de522049dde5e5d10b2aa240924bc4be
+#
+# Precache
+- key: precache_img
+  source: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.20.0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-precache-4-20@sha256:a09bdc86b7df18f5bb797f228228123474d7fad39d1566e4e33dcbd10f9e9d32
+#
+# Recovery
+- key: recovery_img
+  source: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.20.0
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-recovery-4-20@sha256:9ed52e744e9123b3050b68e37dc9b5a861e332ed73526f88395ec0a434cd9706
+#

--- a/test/overlay/talm/4.20/00.data/release.in.yaml
+++ b/test/overlay/talm/4.20/00.data/release.in.yaml
@@ -1,0 +1,12 @@
+---
+variables:
+  # PLACEHOLDER_ variables will be substituted by ad-hoc overlay logic
+  containerImage: PLACEHOLDER_CONTAINER_IMAGE
+  description: |
+      Topology Aware Lifecycle Manager is an operator that facilitates
+      platform and operator upgrades of group of clusters
+  display_name: "Topology Aware Lifecycle Manager"
+  manager_version: "topology-aware-lifecycle-manager.v4.20.0"
+  min_kube_version: "1.32.0"
+  version: "4.20.0"
+

--- a/test/overlay/talm/4.20/00.test.sh
+++ b/test/overlay/talm/4.20/00.test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Source the common test library
+# shellcheck source=test/overlay/common-test-lib.sh
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../../common-test-lib.sh
+
+# Initialize debug mode from command line argument
+init_debug_mode "${1:-}"
+
+# Run the CSV overlay test for cluster-group-upgrades-operator
+run_csv_overlay_test "cluster-group-upgrades-operator" "cluster-group-upgrades-operator CSV overlay test" "00.data"


### PR DESCRIPTION
1. Introduce a new bundle overlay, `konflux-bundle-overlay.sh` , common for all operators, to be used via git submodule when adding this repository from upstream operators. This script adds a `--set-release-file` for individual operator customization.
See an example of a `release.in.yaml` file here for [lca 4.20](https://github.com/openshift-kni/telco5g-konflux/blob/dbc27ffbec08db34845ee9f1fa90bfd94c6891d1/test/overlay/lca/4.20/00.data/release.in.yaml).

2. Introduce a new test framework to test that previous script: see `TEST_OVERLAY.md` in the test folder for usage examples and `TEST_SHARED_FRAMEWORK` for the test framework design, shared among operators: it can potentially test changes for all operators across all releases when modifying the overlay logic if the corresponding CSVs are provided as part of the test data .
So far, I have included only 4.20 tests for all operators, following the same configuration files they have in the main upstream branch. See the `test` folder and the [lca 4.20 test dir](https://github.com/openshift-kni/telco5g-konflux/tree/c5de3161e651660f78ca018083efdf956aaacd83/test/overlay/lca/4.20) as an example: a `00.test.sh` contains the test  and it will dispatch the test execution to the common framework.
3. Introduce a new github action to exec `make test-overlay` to make those previous tests available via CI. That previous target will run all overlay tests across all releases for all operators. So far, as mentioned above, only 4.20 tests are available for all operators.