### PR TITLE
Improve Makefile scripts for better reliability and output handling

### DIFF
--- a/scripts/rpm-lock/Makefile
+++ b/scripts/rpm-lock/Makefile
@@ -10,7 +10,7 @@ REPO_FILE ?= redhat.repo
 .PHONY: filter-unused-repos
 filter-unused-repos: ## Filter unused repositories from redhat.repo files (use REPO_FILE=path to specify file)
 	@echo "Filtering unused repositories from $(REPO_FILE)..."
-	$(SCRIPT_DIR)/konflux-filter-unused-repos.sh $(REPO_FILE)
+	$(SCRIPT_DIR)/konflux-filter-unused-repos.sh $(REPO_FILE) > $(REPO_FILE).tmp && mv $(REPO_FILE).tmp $(REPO_FILE)
 
 .PHONY: help
 help: ## Display available targets

--- a/scripts/rpm-lock/konflux-filter-unused-repos.sh
+++ b/scripts/rpm-lock/konflux-filter-unused-repos.sh
@@ -26,7 +26,7 @@ if [[ ! -f "$REPO_FILE" ]]; then
     exit 1
 fi
 
-# Use awk to filter the repo file
+# Use awk to filter the repo file and remove excessive newlines
 awk '
 BEGIN {
     in_section = 0
@@ -38,7 +38,7 @@ BEGIN {
 /^\[.*\]$/ {
     # If we were in a section and it was enabled, print it
     if (in_section && enabled) {
-        print current_section
+        printf "%s", current_section
     }
 
     # Start new section
@@ -61,7 +61,7 @@ in_section {
     if ($0 ~ /^[[:space:]]*$/) {
         # If this section was enabled, print it
         if (enabled) {
-            print current_section
+            printf "%s", current_section
         }
         in_section = 0
         current_section = ""
@@ -81,7 +81,7 @@ in_section {
 END {
     # If we were in a section and it was enabled, print it
     if (in_section && enabled) {
-        print current_section
+        printf "%s", current_section
     }
 }
-' "$REPO_FILE"
+' "$REPO_FILE" | sed '/^$/N;/^\n$/d'

--- a/scripts/tekton/konflux-update-task-refs.sh
+++ b/scripts/tekton/konflux-update-task-refs.sh
@@ -49,7 +49,12 @@ for PIPELINE_FILE in "$@"; do
     # Fetch the manifests that are currently used in our pipelines
     IFS=$'\n' read -r -d '' -a active_manifests < <( yq '.spec.tasks[].taskRef.params | filter(.name == "bundle") | .[].value' "$PIPELINE_FILE" && printf '\0' )
 
-    for manifest in "${active_manifests[@]}"; do
-        update_manifest_if_outdated "$manifest"
-    done
+    # Check if we have any manifests to process
+    if [[ ${#active_manifests[@]} -gt 0 ]]; then
+        for manifest in "${active_manifests[@]}"; do
+            update_manifest_if_outdated "$manifest"
+        done
+    else
+        echo "No task manifests found in ${PIPELINE_FILE}"
+    fi
 done


### PR DESCRIPTION
- Update rpm-lock/Makefile to automatically overwrite files instead of outputting to stdout
- Enhance konflux-filter-unused-repos.sh to remove excessive newlines from output
- Fix konflux-update-task-refs.sh to handle unbound variables gracefully