### PR TITLE
Shared library script updates

### DIFF
--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -1,0 +1,16 @@
+---
+name: Makefile CI
+
+"on":
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run make test locally for the download scripts
+        run: make -C scripts/download test-local

--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run make test locally for the download scripts
-        run: make -C scripts/download test-local
+        run: make -C scripts/download test-local || cat scripts/download/tests/test_results.log

--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -12,5 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Remove local jq as it interferes with the test
+        run: sudo apt-get remove -y jq
+      - name: Remove local yq as it interferes with the test
+        run: sudo rm -f $(which yq)
       - name: Run make test locally for the download scripts
         run: make -C scripts/download test-local || cat scripts/download/tests/test_results.log

--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Remove local yq as it interferes with the test
         run: sudo rm -f $(which yq)
       - name: Run make test locally for the download scripts
-        run: make -C scripts/download test-local || cat scripts/download/tests/test_results.log
+        run: make -C scripts/download test-local || (cat scripts/download/tests/test_results.log && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 # The 'all' target is the default goal.
 all: lint
-	@echo "All linting tasks completed successfully."
+	@echo "All linting and testing tasks completed successfully."
 
 .PHONY: venv
 venv: $(TELCO5G_KONFLUX_VENV)

--- a/SUBMODULE_USAGE.md
+++ b/SUBMODULE_USAGE.md
@@ -118,11 +118,10 @@ make -f scripts/catalog/Makefile konflux-generate-catalog-production
 
 #### Custom Versions
 ```bash
-./scripts/download/download-yq.sh v4.44.2         # Install specific yq version
-./scripts/download/download-opm.sh v1.51.0        # Install specific opm version
-./scripts/download/download-jq.sh 1.6.0           # Install specific jq version
-./scripts/download/download-operator-sdk.sh 4.13  # Install operator-sdk for OpenShift 4.13 (latest)
-./scripts/download/download-operator-sdk.sh 4.12.76 # Install operator-sdk for specific OpenShift version
+./scripts/download/download-yq.sh v4.44.2            # Install specific yq version
+./scripts/download/download-opm.sh v1.51.0           # Install specific opm version
+./scripts/download/download-jq.sh 1.6                # Install specific jq version
+./scripts/download/download-operator-sdk.sh v1.38.0  # Install operator-sdk for OpenShift 4.13 (latest)
 ```
 
 #### Custom Install Directory
@@ -130,12 +129,12 @@ make -f scripts/catalog/Makefile konflux-generate-catalog-production
 # Using command line option
 ./scripts/download/download-yq.sh -d /usr/local/bin v4.44.2
 ./scripts/download/download-opm.sh --install-dir /opt/tools v1.51.0
-./scripts/download/download-operator-sdk.sh -d /opt/tools 4.13
+./scripts/download/download-operator-sdk.sh -d /opt/tools v1.38.0
 
 # Using environment variable
 INSTALL_DIR=/opt/bin ./scripts/download/download-yq.sh v4.44.2
 INSTALL_DIR=/usr/local/bin ./scripts/download/download-opm.sh
-INSTALL_DIR=/opt/tools ./scripts/download/download-operator-sdk.sh 4.12
+INSTALL_DIR=/opt/tools ./scripts/download/download-operator-sdk.sh v1.38.0
 ```
 
 #### Help Information
@@ -144,22 +143,6 @@ INSTALL_DIR=/opt/tools ./scripts/download/download-operator-sdk.sh 4.12
 ./scripts/download/download-opm.sh --help          # Show detailed usage information
 ./scripts/download/download-jq.sh --help           # Show detailed usage information
 ./scripts/download/download-operator-sdk.sh --help # Show detailed usage information
-```
-
-### Operator SDK Version Discovery
-
-The operator-sdk download script supports intelligent version discovery:
-
-```bash
-# Major.Minor format - automatically finds latest patch release
-./scripts/download/download-operator-sdk.sh 4.12    # Finds latest 4.12.x (e.g., 4.12.76)
-./scripts/download/download-operator-sdk.sh 4.13    # Finds latest 4.13.x (e.g., 4.13.58)
-
-# Full version format - uses exact version
-./scripts/download/download-operator-sdk.sh 4.12.76 # Uses exactly 4.12.76
-
-# The script automatically determines the correct operator-sdk version
-# based on the OpenShift version from the OpenShift mirror
 ```
 
 ## Catalog Management

--- a/scripts/catalog/Makefile
+++ b/scripts/catalog/Makefile
@@ -7,6 +7,9 @@ SCRIPT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 # Tool installation directory
 TOOL_DIR ?= ./bin
 
+# Container engine
+ENGINE ?= docker
+
 # Tool binaries
 YQ ?= $(TOOL_DIR)/yq
 OPM ?= $(TOOL_DIR)/opm
@@ -33,7 +36,7 @@ QUAY_BUNDLE_IMAGE ?= quay.io/redhat-user-workloads/$(QUAY_TENANT_NAME)/$(PACKAGE
 PRODUCTION_BUNDLE_IMAGE ?= registry.redhat.io/$(PRODUCTION_NAMESPACE)/$(PACKAGE_NAME_KONFLUX)-$(PRODUCTION_BUNDLE_NAME)
 
 # Tool versions for downloads
-OPENSHIFT_VERSION ?= 4.12
+OPERATOR_SDK_VERSION ?= 1.40.0
 
 # Catalog comparison configuration
 UPSTREAM_FBC_IMAGE ?= quay.io/redhat-user-workloads/$(QUAY_TENANT_NAME)/$(PACKAGE_NAME_KONFLUX)-fbc-4-20:latest
@@ -58,8 +61,8 @@ opm: ## Ensure opm is available
 .PHONY: operator-sdk
 operator-sdk: ## Ensure operator-sdk is available
 	@if [ ! -x "$(OPERATOR_SDK)" ]; then \
-		echo "Downloading operator-sdk from OpenShift mirror..."; \
-		$(MAKE) -f $(DOWNLOAD_MAKEFILE) download-operator-sdk DOWNLOAD_INSTALL_DIR=$(TOOL_DIR) DOWNLOAD_OPENSHIFT_VERSION=$(OPENSHIFT_VERSION); \
+		echo "Downloading operator-sdk from GitHub releases..."; \
+		$(MAKE) -f $(DOWNLOAD_MAKEFILE) download-operator-sdk DOWNLOAD_INSTALL_DIR=$(TOOL_DIR) DOWNLOAD_OPERATOR_SDK_VERSION=$(OPERATOR_SDK_VERSION); \
 	fi
 
 .PHONY: update-catalog-template
@@ -81,7 +84,7 @@ konflux-validate-catalog-template-bundle: yq operator-sdk ## Validate the last b
 	set -e ;\
 	bundle=$$($(YQ) ".entries[-1].image" $(CATALOG_TEMPLATE_KONFLUX)) ;\
 	echo "validating the last bundle entry: $${bundle} on catalog template: $(CATALOG_TEMPLATE_KONFLUX)" ;\
-	$(OPERATOR_SDK) bundle validate $${bundle} ;\
+	$(OPERATOR_SDK) bundle validate --image-builder=$(ENGINE) $${bundle} ;\
 	}
 
 .PHONY: konflux-validate-catalog
@@ -94,7 +97,6 @@ konflux-generate-catalog: yq opm ## Generate a quay.io catalog
 	$(SCRIPT_DIR)/konflux-update-catalog-template.sh --set-catalog-template-file $(CATALOG_TEMPLATE_KONFLUX) --set-bundle-builds-file $(BUNDLE_BUILDS_FILE)
 	touch $(CATALOG_KONFLUX)
 	$(OPM) alpha render-template basic --output yaml --migrate-level bundle-object-to-csv-metadata $(CATALOG_TEMPLATE_KONFLUX) > $(CATALOG_KONFLUX)
-	$(OPM) validate $(dir $(CATALOG_KONFLUX))
 
 .PHONY: konflux-generate-catalog-production
 konflux-generate-catalog-production: konflux-generate-catalog ## Generate a registry.redhat.io catalog
@@ -109,7 +111,6 @@ konflux-generate-catalog-production: konflux-generate-catalog ## Generate a regi
 	fi
 	# From now on, all the related images must reference production (registry.redhat.io) exclusively
 	$(SCRIPT_DIR)/konflux-validate-related-images-production.sh --set-catalog-file $(CATALOG_KONFLUX)
-	$(OPM) validate $(dir $(CATALOG_KONFLUX))
 
 .PHONY: konflux-compare-catalog
 konflux-compare-catalog: ## Compare generated catalog with upstream FBC image
@@ -128,7 +129,7 @@ help: ## Display available targets
 	@echo "  CATALOG_FILE             Path to catalog file (default: $(CATALOG_FILE))"
 	@echo "  PACKAGE_NAME_KONFLUX     Package name for Konflux operations (default: $(PACKAGE_NAME_KONFLUX))"
 	@echo "  TOOL_DIR                 Directory for downloaded tools (default: $(TOOL_DIR))"
-	@echo "  OPENSHIFT_VERSION        OpenShift version for operator-sdk downloads (default: $(OPENSHIFT_VERSION))"
+	@echo "  OPERATOR_SDK_VERSION     Operator SDK version for downloads (default: $(OPERATOR_SDK_VERSION))"
 	@echo "  UPSTREAM_FBC_IMAGE       Upstream FBC image for comparison (default: $(UPSTREAM_FBC_IMAGE))"
 	@echo ""
 	@echo "Bundle Image Configuration:"
@@ -145,7 +146,7 @@ help: ## Display available targets
 	@echo "  make konflux-generate-catalog                             # Generate quay.io catalog"
 	@echo "  make konflux-generate-catalog-production                  # Generate registry.redhat.io catalog"
 	@echo "  make konflux-compare-catalog                              # Compare generated catalog with upstream FBC"
-	@echo "  make operator-sdk OPENSHIFT_VERSION=4.12                # Download operator-sdk for specific OpenShift version"
+	@echo "  make operator-sdk OPERATOR_SDK_VERSION=1.39.0           # Download operator-sdk for specific version"
 	@echo ""
 	@echo "Bundle Image Customization Examples:"
 	@echo "  make konflux-generate-catalog-production PACKAGE_NAME_KONFLUX=my-operator"

--- a/scripts/catalog/README.md
+++ b/scripts/catalog/README.md
@@ -1,0 +1,239 @@
+# Catalog Comparison Script
+
+This directory contains the `konflux-compare-catalog.sh` script for comparing generated catalogs with upstream FBC (File-Based Catalog) images.
+
+## Overview
+
+The `konflux-compare-catalog.sh` script validates that a locally generated catalog matches the upstream FBC image catalog exactly. This is crucial for ensuring deployment consistency and catching any discrepancies in the catalog generation process.
+
+## Prerequisites
+
+### Required Tools
+
+- **Container Runtime**: Either `podman` or `docker` must be installed
+- **Checksum Tool**: Either `sha256sum` (Linux) or `shasum` (macOS) must be available
+- **Standard Unix Tools**: `find`, `diff`, `wc`, `mktemp`, `uname`
+
+### Platform Support
+
+The script automatically detects and supports:
+- **Operating Systems**: Linux, macOS (Darwin), and other Unix-like systems
+- **Architectures**: AMD64 (x86_64) and ARM64 (aarch64)
+- **Container Runtimes**: Podman (preferred) or Docker (fallback)
+
+## Usage
+
+### Recommended: Using Make Target
+
+```bash
+make konflux-compare-catalog
+```
+
+### Alternative: Direct Script Usage
+
+```bash
+./konflux-compare-catalog.sh --catalog-path <path> --upstream-image <image>
+```
+
+### Make Target Variables
+
+- `CATALOG_KONFLUX`: Path to the catalog file (default: `catalog.yaml`)
+- `UPSTREAM_FBC_IMAGE`: Upstream FBC image to compare against
+- `PACKAGE_NAME_KONFLUX`: Package name for image URL construction (default: `telco5g-konflux`)
+- `QUAY_TENANT_NAME`: Quay tenant name (default: `telco-5g-tenant`)
+
+### Script Parameters (Direct Usage)
+
+**Required:**
+- `--catalog-path PATH`: Path to the generated catalog file or directory
+- `--upstream-image IMAGE`: Upstream FBC image to compare against
+
+**Optional:**
+- `--temp-dir DIR`: Custom temporary directory for extraction (default: auto-generated)
+- `--no-cleanup`: Preserve temporary files after comparison (useful for debugging)
+- `--verbose`: Enable detailed logging output
+- `--help`: Display help information
+
+## Testing Examples
+
+### Example 1: Using Make Target (Recommended)
+```bash
+# Use default configuration
+make konflux-compare-catalog
+
+# Or with custom variables
+make konflux-compare-catalog \
+  CATALOG_KONFLUX=../../../.konflux/catalog/topology-aware-lifecycle-manager/catalog.yaml \
+  UPSTREAM_FBC_IMAGE=quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-20:latest
+```
+
+### Example 2: Direct Script Usage (Alternative)
+```bash
+# Basic test
+./konflux-compare-catalog.sh \
+  --catalog-path ../../../.konflux/catalog/topology-aware-lifecycle-manager/catalog.yaml \
+  --upstream-image quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-20:latest
+
+# Verbose test with debug
+./konflux-compare-catalog.sh \
+  --catalog-path ../../../.konflux/catalog/topology-aware-lifecycle-manager/catalog.yaml \
+  --upstream-image quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-fbc-4-20:latest \
+  --verbose \
+  --no-cleanup
+```
+
+### Example 3: Package-Specific Configuration
+```bash
+# For cluster-group-upgrades-operator
+make konflux-compare-catalog \
+  PACKAGE_NAME_KONFLUX=cluster-group-upgrades-operator \
+  CATALOG_KONFLUX=../../../.konflux/catalog/topology-aware-lifecycle-manager/catalog.yaml
+
+# For lifecycle-agent
+make konflux-compare-catalog \
+  PACKAGE_NAME_KONFLUX=lifecycle-agent \
+  CATALOG_KONFLUX=../../../.konflux/catalog/lifecycle-agent/catalog.yaml
+```
+
+## How It Works
+
+### Platform Detection and Fallback
+
+1. **Platform Detection**: Automatically detects current OS and architecture
+2. **Primary Attempt**: Tries to pull the upstream image for the current platform
+3. **Fallback**: If current platform fails, falls back to `linux/amd64`
+4. **Consistency**: Uses the same platform for both image pulling and container execution
+
+### Comparison Process
+
+1. **Image Pulling**: Downloads the upstream FBC image with platform fallback
+2. **Catalog Extraction**: Extracts the catalog from the image's `/configs` directory
+3. **File Validation**: Ensures both catalogs exist and are readable
+4. **Content Comparison**: Compares line counts and SHA256 checksums
+5. **Detailed Diff**: Shows exact differences if catalogs don't match
+
+## Expected Output
+
+### Success Case
+```
+✅ VALIDATION PASSED: Generated catalog matches upstream FBC catalog exactly
+   - Both catalogs have 311 lines
+   - Both catalogs have identical checksum: 6915da63b021c5c19f1f1b47f9d8e08e31cd0d848909afce3ab3aa7200f2784e
+```
+
+### Failure Case
+```
+❌ VALIDATION FAILED: Generated catalog differs from upstream FBC catalog
+   - Generated catalog: 311 lines, checksum: abc123...
+   - Upstream catalog: 310 lines, checksum: def456...
+
+Differences found:
+==================
+--- upstream-catalog.yaml
++++ generated-catalog.yaml
+@@ -1,3 +1,4 @@
+ line 1
+ line 2
++new line
+ line 3
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Image Pull Failures
+**Problem**: Cannot pull upstream image
+```
+ERROR: Failed to pull upstream image: quay.io/...
+ERROR: Tried platforms: darwin/arm64 and linux/amd64
+```
+
+**Solutions**:
+- Verify image name and tag are correct
+- Check network connectivity
+- Ensure proper authentication for private registries
+- Try manually pulling the image: `podman pull <image>`
+
+#### 2. Container Runtime Issues
+**Problem**: No container runtime available
+```
+ERROR: Neither podman nor docker is available. A container runtime is required.
+```
+
+**Solutions**:
+- Install Podman: `brew install podman` (macOS) or package manager (Linux)
+- Install Docker: Follow official Docker installation guide
+- Verify installation: `podman --version` or `docker --version`
+
+#### 3. Checksum Tool Missing
+**Problem**: Cannot calculate checksums
+```
+ERROR: Neither sha256sum nor shasum command found. Cannot calculate checksums.
+```
+
+**Solutions**:
+- Linux: Install `coreutils` package
+- macOS: Should be pre-installed; try `xcode-select --install`
+- Verify availability: `which sha256sum` or `which shasum`
+
+#### 4. Catalog File Not Found
+**Problem**: Catalog file missing
+```
+ERROR: Catalog path does not exist: /path/to/catalog.yaml
+```
+
+**Solutions**:
+- Verify the catalog file path is correct
+- Check if the catalog was generated successfully
+- Use absolute paths if relative paths cause issues
+
+### Debugging Tips
+
+1. **Use Verbose Mode**: Always use `--verbose` for detailed execution logs
+2. **Preserve Temp Files**: Use `--no-cleanup` to inspect extracted files
+3. **Manual Inspection**: Check temporary directory contents when debugging
+4. **Container Logs**: Run container commands manually to debug extraction issues
+
+## Integration with Build Systems
+
+### Makefile Integration
+Use the provided make target for automated testing:
+
+```makefile
+.PHONY: test-catalog
+test-catalog:
+	$(MAKE) -C telco5g-konflux/scripts/catalog konflux-compare-catalog \
+		CATALOG_KONFLUX=$(CATALOG_FILE) \
+		UPSTREAM_FBC_IMAGE=$(UPSTREAM_FBC_IMAGE)
+```
+
+### Make Target Variables
+The make target supports these configurable variables:
+
+- `CATALOG_KONFLUX`: Path to the catalog file (default: `catalog.yaml`)
+- `UPSTREAM_FBC_IMAGE`: Upstream FBC image to compare against (default: `quay.io/redhat-user-workloads/telco-5g-tenant/telco5g-konflux-fbc-4-20:latest`)
+- `PACKAGE_NAME_KONFLUX`: Package name for constructing image URLs (default: `telco5g-konflux`)
+- `QUAY_TENANT_NAME`: Quay tenant name (default: `telco-5g-tenant`)
+
+### Direct Script Usage
+For advanced use cases, the script can still be called directly:
+
+```bash
+./konflux-compare-catalog.sh --catalog-path <path> --upstream-image <image> [options]
+```
+
+## Security Considerations
+
+- **SHA256 Checksums**: Uses SHA256 instead of MD5 for better security
+- **Container Isolation**: Runs extraction in isolated containers
+- **Temporary Files**: Automatically cleans up temporary files (unless `--no-cleanup` is used)
+- **Platform Safety**: Validates platform compatibility before execution
+
+## Contributing
+
+When modifying the script:
+1. Test on multiple platforms (Linux, macOS)
+2. Test with both podman and docker
+3. Verify error handling for edge cases
+4. Update this README with any new features or requirements

--- a/scripts/download/Makefile
+++ b/scripts/download/Makefile
@@ -8,7 +8,7 @@ SCRIPT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 DOWNLOAD_YQ_VERSION ?= v4.45.4
 DOWNLOAD_OPM_VERSION ?= v1.52.0
 DOWNLOAD_JQ_VERSION ?= 1.7.1
-DOWNLOAD_OPENSHIFT_VERSION ?= 4.12
+DOWNLOAD_OPERATOR_SDK_VERSION ?= 1.40.0
 
 # Default installation directory
 DOWNLOAD_INSTALL_DIR ?= ./bin
@@ -29,9 +29,9 @@ download-jq: ## Download jq JSON processor (use DOWNLOAD_JQ_VERSION and DOWNLOAD
 	$(SCRIPT_DIR)/download-jq.sh --install-dir $(DOWNLOAD_INSTALL_DIR) $(DOWNLOAD_JQ_VERSION)
 
 .PHONY: download-operator-sdk
-download-operator-sdk: ## Download operator-sdk from OpenShift mirror (use DOWNLOAD_OPENSHIFT_VERSION and DOWNLOAD_INSTALL_DIR to customize)
-	@echo "Downloading operator-sdk for OpenShift $(DOWNLOAD_OPENSHIFT_VERSION) to $(DOWNLOAD_INSTALL_DIR)"
-	OPENSHIFT_VERSION=$(DOWNLOAD_OPENSHIFT_VERSION) $(SCRIPT_DIR)/download-operator-sdk.sh --install-dir $(DOWNLOAD_INSTALL_DIR)
+download-operator-sdk: ## Download operator-sdk from GitHub releases (use DOWNLOAD_OPERATOR_SDK_VERSION and DOWNLOAD_INSTALL_DIR to customize)
+	@echo "Downloading operator-sdk version $(DOWNLOAD_OPERATOR_SDK_VERSION) to $(DOWNLOAD_INSTALL_DIR)"
+	$(SCRIPT_DIR)/download-operator-sdk.sh --install-dir $(DOWNLOAD_INSTALL_DIR) $(DOWNLOAD_OPERATOR_SDK_VERSION)
 
 .PHONY: download-all
 download-all: download-yq download-opm download-jq download-operator-sdk ## Download all tools (yq, opm, jq, operator-sdk)
@@ -45,6 +45,35 @@ clean: ## Remove downloaded tools from install directory
 	rm -f $(DOWNLOAD_INSTALL_DIR)/jq
 	rm -f $(DOWNLOAD_INSTALL_DIR)/operator-sdk
 
+.PHONY: test-containerized
+test-containerized: ## Run tests for all download scripts
+	@echo "Running download script tests in UBI9 container..."
+	@echo "=================================================="
+	podman run --rm -v $(SCRIPT_DIR):/workspace -w /workspace \
+		registry.access.redhat.com/ubi9/ubi:latest \
+		/bin/bash -c "\
+		./tests/test-download-opm.sh; \
+		./tests/test-download-operator-sdk.sh; \
+		./tests/test-download-yq.sh; \
+		./tests/test-download-jq.sh"
+	@echo "All download script tests completed."
+
+.PHONY: test-local
+test-local: ## Run tests locally (may be affected by system-installed tools)
+	@echo "Running download script tests locally..."
+	@echo "========================================"
+	$(SCRIPT_DIR)/tests/test-download-opm.sh
+	$(SCRIPT_DIR)/tests/test-download-operator-sdk.sh
+	$(SCRIPT_DIR)/tests/test-download-yq.sh
+	$(SCRIPT_DIR)/tests/test-download-jq.sh
+	@echo "All download script tests completed."
+
+.PHONY: test-clean
+test-clean: ## Clean test artifacts
+	@echo "Cleaning test artifacts..."
+	rm -rf $(SCRIPT_DIR)/tests/test_bin
+	rm -f $(SCRIPT_DIR)/tests/test_results.log
+
 .PHONY: help
 help: ## Display available targets
 	@echo "Download Scripts"
@@ -53,17 +82,19 @@ help: ## Display available targets
 	@echo "This Makefile provides targets for downloading common tools."
 	@echo ""
 	@echo "Variables:"
-	@echo "  DOWNLOAD_YQ_VERSION         yq version (current: $(DOWNLOAD_YQ_VERSION))"
-	@echo "  DOWNLOAD_OPM_VERSION        opm version (current: $(DOWNLOAD_OPM_VERSION))"
-	@echo "  DOWNLOAD_JQ_VERSION         jq version (current: $(DOWNLOAD_JQ_VERSION))"
-	@echo "  DOWNLOAD_OPENSHIFT_VERSION  OpenShift version for operator-sdk (current: $(DOWNLOAD_OPENSHIFT_VERSION))"
-	@echo "  DOWNLOAD_INSTALL_DIR        Install directory (current: $(DOWNLOAD_INSTALL_DIR))"
+	@echo "  DOWNLOAD_YQ_VERSION           yq version (current: $(DOWNLOAD_YQ_VERSION))"
+	@echo "  DOWNLOAD_OPM_VERSION          opm version (current: $(DOWNLOAD_OPM_VERSION))"
+	@echo "  DOWNLOAD_JQ_VERSION           jq version (current: $(DOWNLOAD_JQ_VERSION))"
+	@echo "  DOWNLOAD_OPERATOR_SDK_VERSION operator-sdk version (current: $(DOWNLOAD_OPERATOR_SDK_VERSION))"
+	@echo "  DOWNLOAD_INSTALL_DIR          Install directory (current: $(DOWNLOAD_INSTALL_DIR))"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make download-all                                        # Download all tools with defaults"
-	@echo "  make download-yq DOWNLOAD_YQ_VERSION=v4.44.2             # Download specific yq version"
-	@echo "  make download-operator-sdk DOWNLOAD_OPENSHIFT_VERSION=4.12.76 # Download operator-sdk for specific OpenShift version"
-	@echo "  make download-all DOWNLOAD_INSTALL_DIR=/usr/local/bin    # Download to custom directory"
+	@echo "  make download-all                                            # Download all tools with defaults"
+	@echo "  make download-yq DOWNLOAD_YQ_VERSION=v4.44.2                 # Download specific yq version"
+	@echo "  make download-operator-sdk DOWNLOAD_OPERATOR_SDK_VERSION=1.39.0 # Download operator-sdk for specific version"
+	@echo "  make download-all DOWNLOAD_INSTALL_DIR=/usr/local/bin        # Download to custom directory"
+	@echo "  make test                                                    # Run all download script tests in UBI9 container"
+	@echo "  make test-local                                              # Run tests locally (faster, may be affected by system tools)"
 	@echo ""
 	@echo "Available targets:"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(SCRIPT_DIR)/Makefile

--- a/scripts/download/download-jq.sh
+++ b/scripts/download/download-jq.sh
@@ -35,9 +35,9 @@ Environment Variables:
     INSTALL_DIR           Install directory (overridden by -d/--install-dir)
 
 Examples:
-    $0                                    # Install default version to default directory
-    $0 1.6.0                             # Install specific version to default directory
-    $0 -d /usr/local/bin 1.6.0           # Install specific version to custom directory
+    $0                                   # Install default version to default directory
+    $0 1.6                               # Install specific version to default directory
+    $0 -d /usr/local/bin 1.6             # Install specific version to custom directory
     $0 --install-dir /tmp/tools          # Install default version to custom directory
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
     $0 --help                            # Show help
@@ -111,7 +111,41 @@ main() {
         # Download binary
         url="https://github.com/jqlang/jq/releases/download/jq-${version}/jq-${os}-${arch}"
         echo "Fetching jq version ${version} with url '${url}'"
-        curl -sL -o "${install_path}" "${url}"
+        # Download with error handling
+        local http_code
+        http_code=$(curl -L -s -o "${install_path}" --write-out "%{http_code}" "${url}" 2>/dev/null)
+        local curl_exit_code=$?
+
+        if [[ $curl_exit_code -ne 0 ]]; then
+            echo "ERROR: Failed to download jq version ${version} (curl failed with exit code ${curl_exit_code})"
+            exit 1
+        fi
+
+        if [[ "$http_code" -ne 200 ]]; then
+            if [[ "$http_code" -eq 404 ]]; then
+                echo "ERROR: jq version ${version} not found for ${os}/${arch}"
+                echo "Available versions can be found at: https://github.com/jqlang/jq/releases"
+            else
+                echo "ERROR: Failed to download jq version ${version} (HTTP ${http_code})"
+            fi
+            exit 1
+        fi
+
+        # Verify the downloaded file is not empty
+        if [[ ! -s "${install_path}" ]]; then
+            echo "ERROR: Downloaded file is empty"
+            exit 1
+        fi
+
+        # Check if the file starts with common error messages
+        local first_line
+        first_line=$(head -n 1 "${install_path}" 2>/dev/null || echo "")
+        if [[ "$first_line" =~ ^[[:space:]]*(Not[[:space:]]+Found|404|Error|<html|<HTML) ]]; then
+            echo "ERROR: Downloaded file appears to be an error message, not a binary"
+            echo "First line: $first_line"
+            exit 1
+        fi
+
         chmod +x "${install_path}"
 
         # Verify the installation was successful

--- a/scripts/download/download-operator-sdk.sh
+++ b/scripts/download/download-operator-sdk.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-# This script automates the download and installation of operator-sdk from OpenShift mirror.
-# It first checks if operator-sdk is already installed on the system. If not, it automatically
-# detects the operating system and architecture, then downloads the appropriate
-# tar.gz archive from the OpenShift mirror and extracts the binary.
-# The operator SDK version is automatically determined based on the OpenShift version.
+# This script automates the download and installation of operator-sdk from GitHub releases.
+# It first checks if operator-sdk is available in the system PATH or local install directory.
+# If found, it compares the version to ensure it meets the minimum requirement.
+# It only downloads if no suitable version is found.
 
 # Configure shell to exit immediately if a command exits with a non-zero status,
 # treat unset variables as an error, and fail a pipeline if any command fails.
@@ -17,111 +16,77 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Default installation directory relative to the script's location.
 DEFAULT_INSTALL_DIR="${SCRIPT_DIR}/../bin"
 
-# Default OpenShift version for operator-sdk download from OpenShift mirror.
+# Default operator-sdk version for download from GitHub releases.
 # You can find available versions at:
-# https://mirror.openshift.com/pub/openshift-v4/
-DEFAULT_OPENSHIFT_VERSION="4.12"
+# https://github.com/operator-framework/operator-sdk/releases
+DEFAULT_OPERATOR_SDK_VERSION="1.40.0"
 
 usage() {
     cat << EOF
-Usage: $0 [OPTIONS] [OPENSHIFT_VERSION]
+Usage: $0 [OPTIONS] [OPERATOR_SDK_VERSION]
 
-Downloads and installs operator-sdk from OpenShift mirror.
-The operator SDK version is automatically determined based on the OpenShift version.
+Downloads and installs operator-sdk from GitHub releases if necessary.
+Checks system PATH and local install directory first, and only downloads
+if the existing version doesn't meet the minimum requirement.
 
 Arguments:
-    OPENSHIFT_VERSION     OpenShift version for mirror path (default: ${DEFAULT_OPENSHIFT_VERSION})
-                        Format: X.Y (e.g., 4.12) or X.Y.Z (e.g., 4.12.76)
-                        When using X.Y format, the latest release is automatically found
+    OPERATOR_SDK_VERSION  Minimum operator SDK version required (default: ${DEFAULT_OPERATOR_SDK_VERSION})
+                         Format: X.Y.Z (e.g., 1.40.0) or vX.Y.Z (e.g., v1.40.0)
 
 Options:
     -d, --install-dir DIR Install directory (default: ${DEFAULT_INSTALL_DIR})
     -h, --help            Show this help message
 
 Environment Variables:
-    INSTALL_DIR           Install directory (overridden by -d/--install-dir)
-    OPENSHIFT_VERSION     OpenShift version (overridden by positional argument)
+    INSTALL_DIR             Install directory (overridden by -d/--install-dir)
+    OPERATOR_SDK_VERSION    Minimum operator SDK version (overridden by positional argument)
 
 Examples:
-    $0                                    # Install for default OpenShift version to default directory
-    $0 4.12                              # Install for latest 4.12.x version
-    $0 4.12.76                           # Install for specific OpenShift version
-    $0 -d /usr/local/bin 4.12            # Install to custom directory
-    $0 --install-dir /tmp/tools          # Install for default OpenShift version to custom directory
+    $0                                    # Ensure default version is available
+    $0 1.40.0                            # Ensure minimum version 1.40.0 is available
+    $0 v1.40.0                           # Ensure minimum version 1.40.0 is available (with v prefix)
+    $0 -d /usr/local/bin 1.40.0          # Install to custom directory if needed
+    $0 --install-dir /tmp/tools          # Install to custom directory if needed
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
     $0 --help                            # Show help
 
 EOF
 }
 
-# Function to find the latest release for a given Major.Minor version
-get_latest_release() {
-    local major_minor="$1"
-    local arch="$2"
+# Function to compare version strings
+# Returns 0 if version1 >= version2, 1 otherwise
+version_compare() {
+    local version1="$1"
+    local version2="$2"
 
-    echo "Finding latest release for OpenShift ${major_minor}..." >&2
+    # Remove 'v' prefix if present
+    version1="${version1#v}"
+    version2="${version2#v}"
 
-    # List the directory contents to find available versions
-    local base_url="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/operator-sdk/"
-
-    local listing
-    if listing=$(curl -s "${base_url}" 2>/dev/null); then
-        # Extract versions that match the Major.Minor pattern and find the latest
-        # Use a portable approach that works on both BSD sed (macOS) and GNU sed (Linux)
-        local latest_version
-        latest_version=$(echo "$listing" | \
-                        grep -o "href=\"${major_minor}\.[0-9][0-9]*/" | \
-                        cut -d'"' -f2 | \
-                        tr -d '/' | \
-                        sort -V | \
-                        tail -1)
-
-        if [[ -n "$latest_version" ]]; then
-            echo "$latest_version"
-            return 0
-        fi
+    # Use sort -V to compare versions
+    if [[ "$(printf '%s\n' "$version1" "$version2" | sort -V | head -n1)" == "$version2" ]]; then
+        return 0  # version1 >= version2
+    else
+        return 1  # version1 < version2
     fi
-
-    # If we can't discover it, return empty and we'll handle the error in main
-    echo ""
-    return 1
 }
 
-# Function to determine the operator SDK version for a given OpenShift version
+# Function to get operator-sdk version from a binary path
 get_operator_sdk_version() {
-    local openshift_version="$1"
-    local arch="$2"
-    local os="$3"
+    local binary_path="$1"
 
-    # List the directory contents to find available operator-sdk files
-    local base_url="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/operator-sdk/${openshift_version}/"
-
-    echo "Discovering available operator-sdk version for OpenShift ${openshift_version}..." >&2
-
-    # Try to get directory listing and extract operator SDK version
-    local listing
-    if listing=$(curl -s "${base_url}" 2>/dev/null); then
-        # Look for operator-sdk files and extract version using portable approach
-        local operator_sdk_version
-        operator_sdk_version=$(echo "$listing" | \
-                        grep -o "operator-sdk-v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-ocp-${os}-${arch}\.tar\.gz" | \
-                        head -1 | \
-                        cut -d'-' -f3)
-
-        if [[ -n "$operator_sdk_version" ]]; then
-            echo "$operator_sdk_version"
-            return 0
+    if [[ -x "$binary_path" ]]; then
+        # Try to get version, extract just the version number
+        local version_output
+        if version_output=$(bash -c "$binary_path version" 2>/dev/null); then
+            echo "$version_output" | head -1 | grep -o 'v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*' | head -1
         fi
     fi
-
-    # If we can't discover it, return empty and we'll handle the error in main
-    echo ""
-    return 1
 }
 
 main() {
     # Parse command line arguments
-    local openshift_version="${OPENSHIFT_VERSION:-${DEFAULT_OPENSHIFT_VERSION}}"
+    local operator_sdk_version="${OPERATOR_SDK_VERSION:-${DEFAULT_OPERATOR_SDK_VERSION}}"
     local install_dir="${INSTALL_DIR:-${DEFAULT_INSTALL_DIR}}"
 
     while [[ $# -gt 0 ]]; do
@@ -145,17 +110,17 @@ main() {
                 exit 1
                 ;;
             *)
-                # Positional argument is OpenShift version
-                # Accept both X.Y and X.Y.Z formats, with or without 'v' prefix
+                # Positional argument is operator SDK version
+                # Accept both X.Y.Z and vX.Y.Z formats
                 local version_arg="$1"
                 # Remove 'v' prefix if present
                 version_arg="${version_arg#v}"
 
-                if [[ "$version_arg" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-                    openshift_version="$version_arg"
+                if [[ "$version_arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    operator_sdk_version="$version_arg"
                     shift
                 else
-                    echo "Error: Invalid OpenShift version format: $1 (should be X.Y or X.Y.Z)"
+                    echo "Error: Invalid operator SDK version format: $1 (should be X.Y.Z)"
                     usage
                     exit 1
                 fi
@@ -166,110 +131,158 @@ main() {
     # Define the full path where the operator-sdk binary will be saved.
     local install_path="${install_dir}/operator-sdk"
 
-    # Check if the 'operator-sdk' command is not already available in the system's PATH.
-    # The 'which' command returns a non-zero exit code if the command is not found.
-    if ! which operator-sdk > /dev/null 2>&1; then
-        echo "operator-sdk not found. Starting download..."
+    echo "Checking for operator-sdk with minimum version v${operator_sdk_version}..."
 
-        # Detect the system's machine architecture (e.g., x86_64, aarch64).
-        arch=$(uname -m)
-        # Detect the system's operating system name (e.g., Darwin, Linux).
-        os=$(uname)
+    # Check if operator-sdk is available in system PATH
+    local system_binary=""
+    if system_binary=$(command -v operator-sdk 2>/dev/null); then
+        echo "Found operator-sdk in system PATH: $system_binary"
 
-        # Normalize the OS name to match the format used in OpenShift mirror.
-        # 'Darwin', the name for macOS, is normalized to 'darwin'.
-        if [[ "${os}" == "Darwin" ]]; then
-            os="darwin"
-            echo "Normalized OS name to '${os}'"
-        fi
-        # 'Linux' is normalized to 'linux'.
-        if [[ "${os}" == "Linux" ]]; then
-            os="linux"
-            echo "Normalized OS name to '${os}'"
-        fi
+        local system_version
+        if system_version=$(get_operator_sdk_version "$system_binary"); then
+            echo "System operator-sdk version: $system_version"
 
-        # Normalize the architecture name to match the format used in OpenShift mirror.
-        # Note: OpenShift mirror uses different architecture naming than GitHub releases
-        if [[ "${arch}" == "arm64" ]]; then
-            arch="aarch64"
-            echo "Normalized architecture to '${arch}'"
-        fi
-        # x86_64 stays as x86_64 for OpenShift mirror
-        if [[ "${arch}" == "x86_64" ]]; then
-            echo "Using architecture '${arch}'"
-        fi
-
-        # If the version is in Major.Minor format, find the latest release
-        local resolved_version="$openshift_version"
-        if [[ "$openshift_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "Resolving latest release for OpenShift ${openshift_version}..."
-            if ! resolved_version=$(get_latest_release "$openshift_version" "$arch"); then
-                echo "Error: Could not find latest release for OpenShift ${openshift_version}"
-                echo "Please check if the OpenShift version is valid and available on the mirror."
-                exit 1
+            if version_compare "$system_version" "v$operator_sdk_version"; then
+                echo "System operator-sdk version $system_version meets minimum requirement v$operator_sdk_version"
+                return 0
+            else
+                echo "System operator-sdk version $system_version is below minimum requirement v$operator_sdk_version"
             fi
-
-            if [[ -z "$resolved_version" ]]; then
-                echo "Error: No releases found for OpenShift ${openshift_version} on ${arch}"
-                echo "Available versions can be found at: https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/operator-sdk/"
-                exit 1
-            fi
-
-            echo "Found latest release: ${resolved_version}"
+        else
+            echo "Could not determine system operator-sdk version"
         fi
-
-        # Automatically determine the operator SDK version for the given OpenShift version
-        echo "Determining operator SDK version for OpenShift ${resolved_version}..."
-        local operator_sdk_version
-        if ! operator_sdk_version=$(get_operator_sdk_version "$resolved_version" "$arch" "$os"); then
-            echo "Error: Could not determine operator SDK version for OpenShift ${resolved_version}"
-            echo "Please check if the OpenShift version is valid and available on the mirror."
-            exit 1
-        fi
-
-        if [[ -z "$operator_sdk_version" ]]; then
-            echo "Error: No operator SDK found for OpenShift ${resolved_version} on ${os}/${arch}"
-            echo "Available versions can be found at: https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/operator-sdk/"
-            exit 1
-        fi
-
-        echo "Found operator SDK version: ${operator_sdk_version}"
-
-        # Create the installation directory if it doesn't already exist.
-        # The '-p' flag ensures that parent directories are also created if needed.
-        echo "Creating directory '${install_dir}'"
-        mkdir -p "${install_dir}"
-
-        # Construct the download URL for the specified versions, OS, and architecture.
-        # Format: https://mirror.openshift.com/pub/openshift-v4/{arch}/clients/operator-sdk/{openshift_version}/operator-sdk-{operator_sdk_version}-ocp-{os}-{arch}.tar.gz
-        url="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/operator-sdk/${resolved_version}/operator-sdk-${operator_sdk_version}-ocp-${os}-${arch}.tar.gz"
-
-        # Download and extract the operator-sdk archive using curl and tar.
-        # -L: Follow redirects
-        # -v: Verbose output
-        # tar flags: --strip-components 2 removes first 2 directory levels, -xz extracts gzipped tar, -C specifies output directory
-        echo "Fetching operator-sdk version ${operator_sdk_version} (OpenShift ${resolved_version}) with url '${url}'"
-        curl -L "${url}" | tar --strip-components 2 -xz -C "${install_dir}/"
-
-        # Make the downloaded file executable (should already be executable from tar).
-        chmod +x "${install_path}"
-
-        # Verify that the downloaded binary runs and reports a version.
-        # This confirms the download and installation were successful.
-        if ! bash -c "${install_path} version" > /dev/null 2>&1; then
-            echo "Failed to install tool - binary doesn't execute properly"
-            exit 1
-        fi
-
-        # Get the actual version for confirmation
-        actual_version=$(bash -c "${install_path} version" | head -1 || echo "version check failed")
-        echo "operator-sdk installed successfully to ${install_path}"
-        echo "Installed version: ${actual_version}"
     else
-        echo "operator-sdk is already installed at: $(which operator-sdk)"
-        installed_version=$(operator-sdk version | head -1 || echo "version check failed")
-        echo "Current version: ${installed_version}"
+        echo "operator-sdk not found in system PATH"
     fi
+
+    # Check if operator-sdk exists in local install directory
+    if [[ -x "$install_path" ]]; then
+        echo "Found operator-sdk in local install directory: $install_path"
+
+        local local_version
+        if local_version=$(get_operator_sdk_version "$install_path"); then
+            echo "Local operator-sdk version: $local_version"
+
+            if version_compare "$local_version" "v$operator_sdk_version"; then
+                echo "Local operator-sdk version $local_version meets minimum requirement v$operator_sdk_version"
+                return 0
+            else
+                echo "Local operator-sdk version $local_version is below minimum requirement v$operator_sdk_version"
+            fi
+        else
+            echo "Could not determine local operator-sdk version"
+        fi
+    else
+        echo "operator-sdk not found in local install directory: $install_path"
+    fi
+
+    # No suitable version found, proceed with download
+    echo "Downloading operator-sdk v$operator_sdk_version..."
+
+    # Detect the system's machine architecture (e.g., x86_64, aarch64).
+    arch=$(uname -m)
+    # Detect the system's operating system name (e.g., Darwin, Linux).
+    os=$(uname)
+
+    # Normalize the OS name to match the format used in GitHub releases.
+    # 'Darwin', the name for macOS, is normalized to 'darwin'.
+    if [[ "${os}" == "Darwin" ]]; then
+        os="darwin"
+        echo "Normalized OS name to '${os}'"
+    fi
+    # 'Linux' is normalized to 'linux'.
+    if [[ "${os}" == "Linux" ]]; then
+        os="linux"
+        echo "Normalized OS name to '${os}'"
+    fi
+
+    # Normalize the architecture name to match the format used in GitHub releases.
+    # Note: GitHub releases use different architecture naming than OpenShift mirror
+    if [[ "${arch}" == "aarch64" ]]; then
+        arch="arm64"
+        echo "Normalized architecture to '${arch}'"
+    elif [[ "${arch}" == "x86_64" ]]; then
+        arch="amd64"
+        echo "Normalized architecture to '${arch}'"
+    fi
+
+    # Create the installation directory if it doesn't already exist.
+    # The '-p' flag ensures that parent directories are also created if needed.
+    echo "Creating directory '${install_dir}'"
+    mkdir -p "${install_dir}"
+
+    # Construct the download URL for the specified version, OS, and architecture.
+    # Format: https://github.com/operator-framework/operator-sdk/releases/download/v{version}/operator-sdk_{os}_{arch}
+    url="https://github.com/operator-framework/operator-sdk/releases/download/v${operator_sdk_version}/operator-sdk_${os}_${arch}"
+
+    # Create a temporary file for the download
+    local temp_file="${install_path}.tmp"
+
+    # Download the operator-sdk binary using curl.
+    # -L: Follow redirects
+    # -s: Silent mode (don't show progress)
+    # -o: Output to specific file
+    # --write-out: Output HTTP response code
+    echo "Fetching operator-sdk version v${operator_sdk_version} with url '${url}'"
+
+    local http_code
+    http_code=$(curl -L -s -o "${temp_file}" --write-out "%{http_code}" "${url}" 2>/dev/null)
+    local curl_exit_code=$?
+
+    if [[ $curl_exit_code -ne 0 ]]; then
+        # Clean up temporary file if it exists
+        [[ -f "$temp_file" ]] && rm -f "$temp_file"
+        echo "Error: Failed to download operator-sdk version v${operator_sdk_version} (curl failed with exit code ${curl_exit_code})"
+        exit 1
+    fi
+
+    if [[ "$http_code" -ne 200 ]]; then
+        # Clean up temporary file if it exists
+        [[ -f "$temp_file" ]] && rm -f "$temp_file"
+
+        if [[ "$http_code" -eq 404 ]]; then
+            echo "Error: operator-sdk version v${operator_sdk_version} not found for ${os}/${arch}"
+            echo "Available versions can be found at: https://github.com/operator-framework/operator-sdk/releases"
+        else
+            echo "Error: Failed to download operator-sdk version v${operator_sdk_version} (HTTP ${http_code})"
+        fi
+        exit 1
+    fi
+
+    # Verify the downloaded file is not empty and appears to be a binary
+    if [[ ! -s "$temp_file" ]]; then
+        echo "Error: Downloaded file is empty"
+        rm -f "$temp_file"
+        exit 1
+    fi
+
+    # Check if the file starts with common error messages (case-insensitive)
+    local first_line
+    first_line=$(head -n 1 "$temp_file" 2>/dev/null || echo "")
+    if [[ "$first_line" =~ ^[[:space:]]*(Not[[:space:]]+Found|404|Error|<html|<HTML) ]]; then
+        echo "Error: Downloaded file appears to be an error message, not a binary"
+        echo "First line: $first_line"
+        rm -f "$temp_file"
+        exit 1
+    fi
+
+    # Move the temporary file to the final location
+    mv "$temp_file" "$install_path"
+
+    # Make the downloaded file executable.
+    chmod +x "${install_path}"
+
+    # Verify that the downloaded binary runs and reports a version.
+    # This confirms the download and installation were successful.
+    if ! bash -c "${install_path} version" > /dev/null 2>&1; then
+        echo "Failed to install tool - binary doesn't execute properly"
+        exit 1
+    fi
+
+    # Get the actual version for confirmation
+    actual_version=$(bash -c "${install_path} version" | head -1 || echo "version check failed")
+    echo "operator-sdk installed successfully to ${install_path}"
+    echo "Installed version: ${actual_version}"
 }
 
 # Execute the main function, passing along any arguments provided to the script.

--- a/scripts/download/download-opm.sh
+++ b/scripts/download/download-opm.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # This script automates the download and installation of opm (Operator Package Manager).
-# It first checks if opm is already installed on the system. If not, it automatically
-# detects the operating system and architecture, then downloads the appropriate
-# binary from the official operator-sdk GitHub releases.
+# It first checks if opm is available in the system PATH or local install directory.
+# If found, it compares the version to ensure it meets the minimum requirement.
+# It only downloads if no suitable version is found.
 
 # Configure shell to exit immediately if a command exits with a non-zero status,
 # treat unset variables as an error, and fail a pipeline if any command fails.
@@ -25,10 +25,12 @@ usage() {
     cat << EOF
 Usage: $0 [OPTIONS] [VERSION]
 
-Downloads and installs opm (Operator Package Manager).
+Downloads and installs opm (Operator Package Manager) if necessary.
+Checks system PATH and local install directory first, and only downloads
+if the existing version doesn't meet the minimum requirement.
 
 Arguments:
-    VERSION               Version to install (default: ${DEFAULT_VERSION})
+    VERSION               Minimum version required (default: ${DEFAULT_VERSION})
                          Format: vX.Y.Z (e.g., v1.52.0)
 
 Options:
@@ -39,14 +41,45 @@ Environment Variables:
     INSTALL_DIR           Install directory (overridden by -d/--install-dir)
 
 Examples:
-    $0                                    # Install default version to default directory
-    $0 v1.51.0                           # Install specific version to default directory
-    $0 -d /usr/local/bin v1.51.0         # Install specific version to custom directory
-    $0 --install-dir /tmp/tools          # Install default version to custom directory
+    $0                                    # Ensure default version is available
+    $0 v1.51.0                           # Ensure minimum version v1.51.0 is available
+    $0 -d /usr/local/bin v1.51.0         # Install to custom directory if needed
+    $0 --install-dir /tmp/tools          # Install to custom directory if needed
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
     $0 --help                            # Show help
 
 EOF
+}
+
+# Function to compare version strings
+# Returns 0 if version1 >= version2, 1 otherwise
+version_compare() {
+    local version1="$1"
+    local version2="$2"
+
+    # Remove 'v' prefix if present
+    version1="${version1#v}"
+    version2="${version2#v}"
+
+    # Use sort -V to compare versions
+    if [[ "$(printf '%s\n' "$version1" "$version2" | sort -V | head -n1)" == "$version2" ]]; then
+        return 0  # version1 >= version2
+    else
+        return 1  # version1 < version2
+    fi
+}
+
+# Function to get opm version from a binary path
+get_opm_version() {
+    local binary_path="$1"
+
+    if [[ -x "$binary_path" ]]; then
+        # Try to get version, extract just the version number
+        local version_output
+        if version_output=$(bash -c "$binary_path version" 2>/dev/null); then
+            echo "$version_output" | grep -o 'v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*' | head -1
+        fi
+    fi
 }
 
 main() {
@@ -75,8 +108,19 @@ main() {
                 exit 1
                 ;;
             *)
-                version="$1"
-                shift
+                # Positional argument is version
+                if [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    version="$1"
+                    # Add 'v' prefix if not present
+                    if [[ "$version" != v* ]]; then
+                        version="v$version"
+                    fi
+                    shift
+                else
+                    echo "Error: Invalid version format: $1 (should be vX.Y.Z or X.Y.Z)"
+                    usage
+                    exit 1
+                fi
                 ;;
         esac
     done
@@ -84,67 +128,168 @@ main() {
     # Define the full path where the opm binary will be saved.
     local install_path="${install_dir}/opm"
 
-    # Check if the 'opm' command is not already available in the system's PATH.
-    # The 'which' command returns a non-zero exit code if the command is not found.
-    if ! which opm > /dev/null 2>&1; then
-        echo "opm not found. Starting download..."
+    echo "Checking for opm with minimum version ${version}..."
 
-        # Detect the system's machine architecture (e.g., x86_64, aarch64).
-        arch=$(uname -m)
-        # Detect the system's operating system name (e.g., Darwin, Linux).
-        os=$(uname)
+    # Check if opm is available in system PATH
+    local system_binary=""
+    if system_binary=$(command -v opm 2>/dev/null); then
+        echo "Found opm in system PATH: $system_binary"
 
-        # Normalize the architecture name to match the format used in opm release artifacts.
-        # For example, the common 'x86_64' is referred to as 'amd64' in the releases.
-        if [[ "${arch}" == "x86_64" ]]; then
-            arch="amd64"
-            echo "Normalized architecture to '${arch}'"
+        local system_version
+        if system_version=$(get_opm_version "$system_binary"); then
+            echo "System opm version: $system_version"
+
+            if version_compare "$system_version" "$version"; then
+                echo "System opm version $system_version meets minimum requirement $version"
+                return 0
+            else
+                echo "System opm version $system_version is below minimum requirement $version"
+            fi
+        else
+            echo "Could not determine system opm version"
         fi
-        # 'aarch64' is normalized to 'arm64'.
-        if [[ "${arch}" == "aarch64" ]]; then
-            arch="arm64"
-            echo "Normalized architecture to '${arch}'"
-        fi
-
-        # Normalize the OS name to match the format used in opm release artifacts.
-        # 'Darwin', the name for macOS, is normalized to 'darwin'.
-        if [[ "${os}" == "Darwin" ]]; then
-            os="darwin"
-            echo "Normalized OS name to '${os}'"
-        fi
-        # 'Linux' is normalized to 'linux'.
-        if [[ "${os}" == "Linux" ]]; then
-            os="linux"
-            echo "Normalized OS name to '${os}'"
-        fi
-
-        # Create the installation directory if it doesn't already exist.
-        # The '-p' flag ensures that parent directories are also created if needed.
-        echo "Creating directory '${install_dir}'"
-        mkdir -p "${install_dir}"
-
-        # Construct the download URL for the specified version, OS, and architecture.
-        url="https://github.com/operator-framework/operator-registry/releases/download/${version}/${os}-${arch}-opm"
-
-        # Download the opm binary using curl.
-        # -sL: Silent mode to suppress progress meter, and -L to follow redirects.
-        # -o: Specify the output file path.
-        echo "Fetching opm version ${version} with url '${url}'"
-        curl -sL -o "${install_path}" "${url}"
-
-        # Make the downloaded file executable.
-        chmod +x "${install_path}"
-
-        # Verify that the downloaded binary runs and reports the correct version.
-        # This confirms the download and installation were successful.
-        if ! bash -c "${install_path} version | grep '${version}'"; then
-            echo "Failed to install tool"
-            exit 1
-        fi
-        echo "opm version ${version} installed successfully to ${install_path}"
     else
-        echo "opm is already installed at: $(which opm)"
+        echo "opm not found in system PATH"
     fi
+
+    # Check if opm exists in local install directory
+    if [[ -x "$install_path" ]]; then
+        echo "Found opm in local install directory: $install_path"
+
+        local local_version
+        if local_version=$(get_opm_version "$install_path"); then
+            echo "Local opm version: $local_version"
+
+            if version_compare "$local_version" "$version"; then
+                echo "Local opm version $local_version meets minimum requirement $version"
+                return 0
+            else
+                echo "Local opm version $local_version is below minimum requirement $version"
+            fi
+        else
+            echo "Could not determine local opm version"
+        fi
+    else
+        echo "opm not found in local install directory: $install_path"
+    fi
+
+    # No suitable version found, proceed with download
+    echo "Downloading opm ${version}..."
+
+    # Detect the system's machine architecture (e.g., x86_64, arm64, aarch64).
+    local arch
+    arch=$(uname -m)
+
+    # Detect the system's operating system name (e.g., Darwin, Linux).
+    local os
+    os=$(uname)
+
+    # Normalize the OS name to match the format used in opm releases.
+    # 'Darwin', the name for macOS, is normalized to 'darwin'.
+    if [[ "${os}" == "Darwin" ]]; then
+        os="darwin"
+        echo "Normalized OS name to '${os}'"
+    fi
+    # 'Linux' is normalized to 'linux'.
+    if [[ "${os}" == "Linux" ]]; then
+        os="linux"
+        echo "Normalized OS name to '${os}'"
+    fi
+
+    # Normalize the architecture name to match the format used in opm releases.
+    # 'x86_64' is normalized to 'amd64'.
+    if [[ "${arch}" == "x86_64" ]]; then
+        arch="amd64"
+        echo "Normalized architecture to '${arch}'"
+    fi
+    # 'aarch64' is normalized to 'arm64'.
+    if [[ "${arch}" == "aarch64" ]]; then
+        arch="arm64"
+        echo "Normalized architecture to '${arch}'"
+    fi
+    # 'arm64' stays as 'arm64'.
+    if [[ "${arch}" == "arm64" ]]; then
+        echo "Using architecture '${arch}'"
+    fi
+
+    # Create the installation directory if it doesn't already exist.
+    # The '-p' flag ensures that parent directories are also created if needed.
+    echo "Creating directory '${install_dir}'"
+    mkdir -p "${install_dir}"
+
+    # Construct the download URL for the specified version, OS, and architecture.
+    # Format: https://github.com/operator-framework/operator-registry/releases/download/{version}/{os}-{arch}-opm
+    local url="https://github.com/operator-framework/operator-registry/releases/download/${version}/${os}-${arch}-opm"
+
+    # Create a temporary file for the download
+    local temp_file="${install_path}.tmp"
+
+    # Download the opm binary using curl. The binary is directly executable, so we
+    # don't need to extract it from an archive.
+    # -L: Follow redirects
+    # -s: Silent mode (don't show progress)
+    # -o: Output to specific file
+    # --write-out: Output HTTP response code
+    echo "Fetching opm ${version} with url '${url}'"
+
+    local http_code
+    http_code=$(curl -L -s -o "${temp_file}" --write-out "%{http_code}" "${url}" 2>/dev/null)
+    local curl_exit_code=$?
+
+    if [[ $curl_exit_code -ne 0 ]]; then
+        # Clean up temporary file if it exists
+        [[ -f "$temp_file" ]] && rm -f "$temp_file"
+        echo "Error: Failed to download opm version ${version} (curl failed with exit code ${curl_exit_code})"
+        exit 1
+    fi
+
+    if [[ "$http_code" -ne 200 ]]; then
+        # Clean up temporary file if it exists
+        [[ -f "$temp_file" ]] && rm -f "$temp_file"
+
+        if [[ "$http_code" -eq 404 ]]; then
+            echo "Error: opm version ${version} not found for ${os}/${arch}"
+            echo "Available versions can be found at: https://github.com/operator-framework/operator-registry/releases"
+        else
+            echo "Error: Failed to download opm version ${version} (HTTP ${http_code})"
+        fi
+        exit 1
+    fi
+
+    # Verify the downloaded file is not empty and appears to be a binary
+    if [[ ! -s "$temp_file" ]]; then
+        echo "Error: Downloaded file is empty"
+        rm -f "$temp_file"
+        exit 1
+    fi
+
+    # Check if the file starts with common error messages (case-insensitive)
+    local first_line
+    first_line=$(head -n 1 "$temp_file" 2>/dev/null || echo "")
+    if [[ "$first_line" =~ ^[[:space:]]*(Not[[:space:]]+Found|404|Error|<html|<HTML) ]]; then
+        echo "Error: Downloaded file appears to be an error message, not a binary"
+        echo "First line: $first_line"
+        rm -f "$temp_file"
+        exit 1
+    fi
+
+    # Move the temporary file to the final location
+    mv "$temp_file" "$install_path"
+
+    # Make the downloaded file executable.
+    chmod +x "${install_path}"
+
+    # Verify that the downloaded binary runs and reports a version.
+    # This confirms the download and installation were successful.
+    if ! bash -c "${install_path} version" > /dev/null 2>&1; then
+        echo "Failed to install tool - binary doesn't execute properly"
+        exit 1
+    fi
+
+    # Get the actual version for confirmation
+    actual_version=$(bash -c "${install_path} version" | head -1 || echo "version check failed")
+    echo "opm version ${version} installed successfully to ${install_path}"
+    echo "Installed version: ${actual_version}"
 }
 
 # Execute the main function, passing along any arguments provided to the script.

--- a/scripts/download/download-yq.sh
+++ b/scripts/download/download-yq.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # This script automates the download and installation of yq, a command-line YAML processor.
-# It first checks if yq is already installed on the system. If not, it automatically
-# detects the operating system and architecture, then downloads the appropriate
-# binary from the official yq GitHub releases.
+# It first checks if yq is available in the system PATH or local install directory.
+# If found, it compares the version to ensure it meets the minimum requirement.
+# It only downloads if no suitable version is found.
 
 # Configure shell to exit immediately if a command exits with a non-zero status,
 # treat unset variables as an error, and fail a pipeline if any command fails.
@@ -25,10 +25,12 @@ usage() {
     cat << EOF
 Usage: $0 [OPTIONS] [VERSION]
 
-Downloads and installs yq, a command-line YAML processor.
+Downloads and installs yq, a command-line YAML processor, if necessary.
+Checks system PATH and local install directory first, and only downloads
+if the existing version doesn't meet the minimum requirement.
 
 Arguments:
-    VERSION               Version to install (default: ${DEFAULT_VERSION})
+    VERSION               Minimum version required (default: ${DEFAULT_VERSION})
                          Format: vX.Y.Z (e.g., v4.45.4)
 
 Options:
@@ -39,14 +41,45 @@ Environment Variables:
     INSTALL_DIR           Install directory (overridden by -d/--install-dir)
 
 Examples:
-    $0                                    # Install default version to default directory
-    $0 v4.44.2                           # Install specific version to default directory
-    $0 -d /usr/local/bin v4.44.2         # Install specific version to custom directory
-    $0 --install-dir /tmp/tools          # Install default version to custom directory
+    $0                                    # Ensure default version is available
+    $0 v4.44.2                           # Ensure minimum version v4.44.2 is available
+    $0 -d /usr/local/bin v4.44.2         # Install to custom directory if needed
+    $0 --install-dir /tmp/tools          # Install to custom directory if needed
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
     $0 --help                            # Show help
 
 EOF
+}
+
+# Function to compare version strings
+# Returns 0 if version1 >= version2, 1 otherwise
+version_compare() {
+    local version1="$1"
+    local version2="$2"
+
+    # Remove 'v' prefix if present
+    version1="${version1#v}"
+    version2="${version2#v}"
+
+    # Use sort -V to compare versions
+    if [[ "$(printf '%s\n' "$version1" "$version2" | sort -V | head -n1)" == "$version2" ]]; then
+        return 0  # version1 >= version2
+    else
+        return 1  # version1 < version2
+    fi
+}
+
+# Function to get yq version from a binary path
+get_yq_version() {
+    local binary_path="$1"
+
+    if [[ -x "$binary_path" ]]; then
+        # Try to get version, extract just the version number
+        local version_output
+        if version_output=$(bash -c "$binary_path --version" 2>/dev/null); then
+            echo "$version_output" | grep -o 'v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*' | head -1
+        fi
+    fi
 }
 
 main() {
@@ -75,8 +108,19 @@ main() {
                 exit 1
                 ;;
             *)
-                version="$1"
-                shift
+                # Positional argument is version
+                if [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    version="$1"
+                    # Add 'v' prefix if not present
+                    if [[ "$version" != v* ]]; then
+                        version="v$version"
+                    fi
+                    shift
+                else
+                    echo "Error: Invalid version format: $1 (should be vX.Y.Z or X.Y.Z)"
+                    usage
+                    exit 1
+                fi
                 ;;
         esac
     done
@@ -84,67 +128,168 @@ main() {
     # Define the full path where the yq binary will be saved.
     local install_path="${install_dir}/yq"
 
-    # Check if the 'yq' command is not already available in the system's PATH.
-    # The 'which' command returns a non-zero exit code if the command is not found.
-    if ! which yq > /dev/null 2>&1; then
-        echo "yq not found. Starting download..."
+    echo "Checking for yq with minimum version ${version}..."
 
-        # Detect the system's machine architecture (e.g., x86_64, aarch64).
-        arch=$(uname -m)
-        # Detect the system's operating system name (e.g., Darwin, Linux).
-        os=$(uname)
+    # Check if yq is available in system PATH
+    local system_binary=""
+    if system_binary=$(command -v yq 2>/dev/null); then
+        echo "Found yq in system PATH: $system_binary"
 
-        # Normalize the architecture name to match the format used in yq release artifacts.
-        # For example, the common 'x86_64' is referred to as 'amd64' in the releases.
-        if [[ "${arch}" == "x86_64" ]]; then
-            arch="amd64"
-            echo "Normalized architecture to '${arch}'"
+        local system_version
+        if system_version=$(get_yq_version "$system_binary"); then
+            echo "System yq version: $system_version"
+
+            if version_compare "$system_version" "$version"; then
+                echo "System yq version $system_version meets minimum requirement $version"
+                return 0
+            else
+                echo "System yq version $system_version is below minimum requirement $version"
+            fi
+        else
+            echo "Could not determine system yq version"
         fi
-        # 'aarch64' is normalized to 'arm64'.
-        if [[ "${arch}" == "aarch64" ]]; then
-            arch="arm64"
-            echo "Normalized architecture to '${arch}'"
-        fi
-
-        # Normalize the OS name to match the format used in yq release artifacts.
-        # 'Darwin', the name for macOS, is normalized to 'darwin'.
-        if [[ "${os}" == "Darwin" ]]; then
-            os="darwin"
-            echo "Normalized OS name to '${os}'"
-        fi
-        # 'Linux' is normalized to 'linux'.
-        if [[ "${os}" == "Linux" ]]; then
-            os="linux"
-            echo "Normalized OS name to '${os}'"
-        fi
-
-        # Create the installation directory if it doesn't already exist.
-        # The '-p' flag ensures that parent directories are also created if needed.
-        echo "Creating directory '${install_dir}'"
-        mkdir -p "${install_dir}"
-
-        # Construct the download URL for the specified version, OS, and architecture.
-        url="https://github.com/mikefarah/yq/releases/download/${version}/yq_${os}_${arch}"
-
-        # Download the yq binary using curl.
-        # -sL: Silent mode to suppress progress meter, and -L to follow redirects.
-        # -o: Specify the output file path.
-        echo "Fetching yq version ${version} with url '${url}'"
-        curl -sL -o "${install_path}" "${url}"
-
-        # Make the downloaded file executable.
-        chmod +x "${install_path}"
-
-        # Verify that the downloaded binary runs and reports the correct version.
-        # This confirms the download and installation were successful.
-        if ! bash -c "${install_path} --version | grep '${version}'"; then
-            echo "Failed to install tool"
-            exit 1
-        fi
-        echo "yq version ${version} installed successfully to ${install_path}"
     else
-        echo "yq is already installed at: $(which yq)"
+        echo "yq not found in system PATH"
     fi
+
+    # Check if yq exists in local install directory
+    if [[ -x "$install_path" ]]; then
+        echo "Found yq in local install directory: $install_path"
+
+        local local_version
+        if local_version=$(get_yq_version "$install_path"); then
+            echo "Local yq version: $local_version"
+
+            if version_compare "$local_version" "$version"; then
+                echo "Local yq version $local_version meets minimum requirement $version"
+                return 0
+            else
+                echo "Local yq version $local_version is below minimum requirement $version"
+            fi
+        else
+            echo "Could not determine local yq version"
+        fi
+    else
+        echo "yq not found in local install directory: $install_path"
+    fi
+
+    # No suitable version found, proceed with download
+    echo "Downloading yq ${version}..."
+
+    # Detect the system's machine architecture (e.g., x86_64, arm64, aarch64).
+    local arch
+    arch=$(uname -m)
+
+    # Detect the system's operating system name (e.g., Darwin, Linux).
+    local os
+    os=$(uname)
+
+    # Normalize the OS name to match the format used in yq releases.
+    # 'Darwin', the name for macOS, is normalized to 'darwin'.
+    if [[ "${os}" == "Darwin" ]]; then
+        os="darwin"
+        echo "Normalized OS name to '${os}'"
+    fi
+    # 'Linux' is normalized to 'linux'.
+    if [[ "${os}" == "Linux" ]]; then
+        os="linux"
+        echo "Normalized OS name to '${os}'"
+    fi
+
+    # Normalize the architecture name to match the format used in yq releases.
+    # 'x86_64' is normalized to 'amd64'.
+    if [[ "${arch}" == "x86_64" ]]; then
+        arch="amd64"
+        echo "Normalized architecture to '${arch}'"
+    fi
+    # 'aarch64' is normalized to 'arm64'.
+    if [[ "${arch}" == "aarch64" ]]; then
+        arch="arm64"
+        echo "Normalized architecture to '${arch}'"
+    fi
+    # 'arm64' stays as 'arm64'.
+    if [[ "${arch}" == "arm64" ]]; then
+        echo "Using architecture '${arch}'"
+    fi
+
+    # Create the installation directory if it doesn't already exist.
+    # The '-p' flag ensures that parent directories are also created if needed.
+    echo "Creating directory '${install_dir}'"
+    mkdir -p "${install_dir}"
+
+    # Construct the download URL for the specified version, OS, and architecture.
+    # Format: https://github.com/mikefarah/yq/releases/download/{version}/yq_{os}_{arch}
+    local url="https://github.com/mikefarah/yq/releases/download/${version}/yq_${os}_${arch}"
+
+    # Create a temporary file for the download
+    local temp_file="${install_path}.tmp"
+
+    # Download the yq binary using curl. The binary is directly executable, so we
+    # don't need to extract it from an archive.
+    # -L: Follow redirects
+    # -s: Silent mode (don't show progress)
+    # -o: Output to specific file
+    # --write-out: Output HTTP response code
+    echo "Fetching yq ${version} with url '${url}'"
+
+    local http_code
+    http_code=$(curl -L -s -o "${temp_file}" --write-out "%{http_code}" "${url}" 2>/dev/null)
+    local curl_exit_code=$?
+
+    if [[ $curl_exit_code -ne 0 ]]; then
+        # Clean up temporary file if it exists
+        [[ -f "$temp_file" ]] && rm -f "$temp_file"
+        echo "Error: Failed to download yq version ${version} (curl failed with exit code ${curl_exit_code})"
+        exit 1
+    fi
+
+    if [[ "$http_code" -ne 200 ]]; then
+        # Clean up temporary file if it exists
+        [[ -f "$temp_file" ]] && rm -f "$temp_file"
+
+        if [[ "$http_code" -eq 404 ]]; then
+            echo "Error: yq version ${version} not found for ${os}/${arch}"
+            echo "Available versions can be found at: https://github.com/mikefarah/yq/releases"
+        else
+            echo "Error: Failed to download yq version ${version} (HTTP ${http_code})"
+        fi
+        exit 1
+    fi
+
+    # Verify the downloaded file is not empty and appears to be a binary
+    if [[ ! -s "$temp_file" ]]; then
+        echo "Error: Downloaded file is empty"
+        rm -f "$temp_file"
+        exit 1
+    fi
+
+    # Check if the file starts with common error messages (case-insensitive)
+    local first_line
+    first_line=$(head -n 1 "$temp_file" 2>/dev/null || echo "")
+    if [[ "$first_line" =~ ^[[:space:]]*(Not[[:space:]]+Found|404|Error|<html|<HTML) ]]; then
+        echo "Error: Downloaded file appears to be an error message, not a binary"
+        echo "First line: $first_line"
+        rm -f "$temp_file"
+        exit 1
+    fi
+
+    # Move the temporary file to the final location
+    mv "$temp_file" "$install_path"
+
+    # Make the downloaded file executable.
+    chmod +x "${install_path}"
+
+    # Verify that the downloaded binary runs and reports a version.
+    # This confirms the download and installation were successful.
+    if ! bash -c "${install_path} --version" > /dev/null 2>&1; then
+        echo "Failed to install tool - binary doesn't execute properly"
+        exit 1
+    fi
+
+    # Get the actual version for confirmation
+    actual_version=$(bash -c "${install_path} --version" | head -1 || echo "version check failed")
+    echo "yq version ${version} installed successfully to ${install_path}"
+    echo "Installed version: ${actual_version}"
 }
 
 # Execute the main function, passing along any arguments provided to the script.

--- a/scripts/download/tests/.gitignore
+++ b/scripts/download/tests/.gitignore
@@ -1,0 +1,2 @@
+test_results.log
+test_bin/

--- a/scripts/download/tests/test-download-jq.sh
+++ b/scripts/download/tests/test-download-jq.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+
+# Test script for download-jq.sh
+# This script tests various scenarios for the jq download script
+
+set -eou pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test directory setup
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DOWNLOAD_SCRIPT="${SCRIPT_DIR}/../download-jq.sh"
+TEST_INSTALL_DIR="${SCRIPT_DIR}/test_bin"
+TEST_LOG_FILE="${SCRIPT_DIR}/test_results.log"
+
+# Test counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Test version constants
+VALID_VERSION_OLD="1.7"
+VALID_VERSION_NEW="1.7.1"
+INVALID_VERSION="999.999.999"
+
+# Utility functions
+log() {
+    echo -e "$1" | tee -a "$TEST_LOG_FILE"
+}
+
+log_test_start() {
+    local test_name="$1"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log "${YELLOW}[TEST ${TOTAL_TESTS}] Starting: $test_name${NC}"
+}
+
+log_test_pass() {
+    local test_name="$1"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+    log "${GREEN}[PASS] $test_name${NC}"
+}
+
+log_test_fail() {
+    local test_name="$1"
+    local error_msg="$2"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+    log "${RED}[FAIL] $test_name${NC}"
+    log "${RED}       Error: $error_msg${NC}"
+}
+
+setup_test_environment() {
+    log "Setting up test environment..."
+
+    # Remove test directory if it exists
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+
+    # Create fresh test directory
+    mkdir -p "$TEST_INSTALL_DIR"
+
+    # Initialize log file
+    echo "jq Download Script Test Results - $(date)" > "$TEST_LOG_FILE"
+    echo "================================================" >> "$TEST_LOG_FILE"
+}
+
+cleanup_test_environment() {
+    log "Cleaning up test environment..."
+
+    # Remove test directory
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+}
+
+create_fake_jq_binary() {
+    local version="$1"
+    local install_path="$2"
+
+    # Create fake jq binary that returns the specified version
+    cat > "$install_path" << EOF
+#!/bin/bash
+echo "jq-$version"
+EOF
+    chmod +x "$install_path"
+}
+
+test_download_valid_version() {
+    log_test_start "Download valid version to empty directory"
+
+    local test_dir="${TEST_INSTALL_DIR}/valid_version"
+    mkdir -p "$test_dir"
+
+    # Test should succeed
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        # Check if binary was created
+        if [[ -x "$test_dir/jq" ]]; then
+            log_test_pass "Download valid version to empty directory"
+        else
+            log_test_fail "Download valid version to empty directory" "Binary not created"
+        fi
+    else
+        log_test_fail "Download valid version to empty directory" "Script failed"
+    fi
+}
+
+test_download_invalid_version() {
+    log_test_start "Download invalid version"
+
+    local test_dir="${TEST_INSTALL_DIR}/invalid_version"
+    mkdir -p "$test_dir"
+
+    # Test should fail (jq script doesn't have version comparison, but URL will be invalid)
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$INVALID_VERSION" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Download invalid version" "Script should have failed but succeeded"
+    else
+        log_test_pass "Download invalid version"
+    fi
+}
+
+test_newer_version_when_old_exists() {
+    log_test_start "Download newer version when old version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/newer_when_old"
+    mkdir -p "$test_dir"
+
+    # Note: jq script doesn't check versions, it only checks if jq exists in PATH
+    # So we need to test without jq in PATH
+    if ! command -v jq > /dev/null 2>&1; then
+        # Test should succeed and download
+        if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+            if [[ -x "$test_dir/jq" ]]; then
+                log_test_pass "Download newer version when old version exists"
+            else
+                log_test_fail "Download newer version when old version exists" "Binary not created"
+            fi
+        else
+            log_test_fail "Download newer version when old version exists" "Script failed"
+        fi
+    else
+        log_test_pass "Download newer version when old version exists (jq found in PATH, skipping download)"
+    fi
+}
+
+test_old_version_when_newer_exists() {
+    log_test_start "Request old version when newer version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/old_when_newer"
+    mkdir -p "$test_dir"
+
+    # Note: jq script doesn't check versions, it only checks if jq exists in PATH
+    if ! command -v jq > /dev/null 2>&1; then
+        # Test should succeed and download
+        if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
+            if [[ -x "$test_dir/jq" ]]; then
+                log_test_pass "Request old version when newer version exists"
+            else
+                log_test_fail "Request old version when newer version exists" "Binary not created"
+            fi
+        else
+            log_test_fail "Request old version when newer version exists" "Script failed"
+        fi
+    else
+        log_test_pass "Request old version when newer version exists (jq found in PATH, skipping download)"
+    fi
+}
+
+test_help_option() {
+    log_test_start "Test help option"
+
+    # Test help option should succeed
+    if "$DOWNLOAD_SCRIPT" --help >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_pass "Test help option"
+    else
+        log_test_fail "Test help option" "Help option failed"
+    fi
+}
+
+test_invalid_option() {
+    log_test_start "Test invalid option"
+
+    # Test invalid option should fail
+    if "$DOWNLOAD_SCRIPT" --invalid-option >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test invalid option" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test invalid option"
+    fi
+}
+
+test_missing_install_dir_argument() {
+    log_test_start "Test missing install directory argument"
+
+    # Test missing install directory argument should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test missing install directory argument" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test missing install directory argument"
+    fi
+}
+
+test_skip_when_jq_in_path() {
+    log_test_start "Test skip download when jq is in PATH"
+
+    local test_dir="${TEST_INSTALL_DIR}/skip_test"
+    mkdir -p "$test_dir"
+
+    # Create fake jq in PATH by adding test directory to PATH temporarily
+    create_fake_jq_binary "$VALID_VERSION_NEW" "$test_dir/jq"
+
+    # Temporarily add test directory to PATH
+    local old_path="$PATH"
+    export PATH="$test_dir:$PATH"
+
+    # Test should succeed but skip download
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_pass "Test skip download when jq is in PATH"
+    else
+        log_test_fail "Test skip download when jq is in PATH" "Script failed"
+    fi
+
+    # Restore PATH
+    export PATH="$old_path"
+}
+
+print_test_summary() {
+    log ""
+    log "================================================"
+    log "Test Summary:"
+    log "Total tests: $TOTAL_TESTS"
+    log "Passed: $PASSED_TESTS"
+    log "Failed: $FAILED_TESTS"
+    log "================================================"
+
+    if [[ $FAILED_TESTS -gt 0 ]]; then
+        log "${RED}Some tests failed. See $TEST_LOG_FILE for details.${NC}"
+        return 1
+    else
+        log "${GREEN}All tests passed!${NC}"
+        return 0
+    fi
+}
+
+main() {
+    log "Starting jq Download Script Tests"
+    log "================================="
+
+    # Check if download script exists
+    if [[ ! -f "$DOWNLOAD_SCRIPT" ]]; then
+        log "${RED}Error: Download script not found at $DOWNLOAD_SCRIPT${NC}"
+        exit 1
+    fi
+
+    setup_test_environment
+
+    # Run tests
+    test_download_valid_version
+    test_download_invalid_version
+    test_newer_version_when_old_exists
+    test_old_version_when_newer_exists
+    test_help_option
+    test_invalid_option
+    test_missing_install_dir_argument
+    test_skip_when_jq_in_path
+
+    cleanup_test_environment
+
+    print_test_summary
+}
+
+# Run main function
+main "$@"

--- a/scripts/download/tests/test-download-operator-sdk.sh
+++ b/scripts/download/tests/test-download-operator-sdk.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+
+# Test script for download-operator-sdk.sh
+# This script tests various scenarios for the Operator SDK download script
+
+set -eou pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test directory setup
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DOWNLOAD_SCRIPT="${SCRIPT_DIR}/../download-operator-sdk.sh"
+TEST_INSTALL_DIR="${SCRIPT_DIR}/test_bin"
+TEST_LOG_FILE="${SCRIPT_DIR}/test_results.log"
+
+# Test counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Test version constants
+VALID_VERSION_OLD="1.40.0"
+VALID_VERSION_NEW="1.41.0"
+INVALID_VERSION="999.999.999"
+
+# Utility functions
+log() {
+    echo -e "$1" | tee -a "$TEST_LOG_FILE"
+}
+
+log_test_start() {
+    local test_name="$1"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log "${YELLOW}[TEST ${TOTAL_TESTS}] Starting: $test_name${NC}"
+}
+
+log_test_pass() {
+    local test_name="$1"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+    log "${GREEN}[PASS] $test_name${NC}"
+}
+
+log_test_fail() {
+    local test_name="$1"
+    local error_msg="$2"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+    log "${RED}[FAIL] $test_name${NC}"
+    log "${RED}       Error: $error_msg${NC}"
+}
+
+setup_test_environment() {
+    log "Setting up test environment..."
+
+    # Remove test directory if it exists
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+
+    # Create fresh test directory
+    mkdir -p "$TEST_INSTALL_DIR"
+
+    # Initialize log file
+    echo "Operator SDK Download Script Test Results - $(date)" > "$TEST_LOG_FILE"
+    echo "================================================" >> "$TEST_LOG_FILE"
+}
+
+cleanup_test_environment() {
+    log "Cleaning up test environment..."
+
+    # Remove test directory
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+}
+
+create_fake_operator_sdk_binary() {
+    local version="$1"
+    local install_path="$2"
+
+    # Create fake operator-sdk binary that returns the specified version
+    cat > "$install_path" << EOF
+#!/bin/bash
+echo "operator-sdk version: \"v$version\", commit: \"abc123\", kubernetes version: \"v1.25.0\", go version: \"go1.19.5\", GOOS: \"linux\", GOARCH: \"amd64\""
+EOF
+    chmod +x "$install_path"
+}
+
+test_download_valid_version() {
+    log_test_start "Download valid version to empty directory"
+
+    local test_dir="${TEST_INSTALL_DIR}/valid_version"
+    mkdir -p "$test_dir"
+
+    # Test should succeed
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        # Check if binary was created
+        if [[ -x "$test_dir/operator-sdk" ]]; then
+            log_test_pass "Download valid version to empty directory"
+        else
+            log_test_fail "Download valid version to empty directory" "Binary not created"
+        fi
+    else
+        log_test_fail "Download valid version to empty directory" "Script failed"
+    fi
+}
+
+test_download_invalid_version() {
+    log_test_start "Download invalid version"
+
+    local test_dir="${TEST_INSTALL_DIR}/invalid_version"
+    mkdir -p "$test_dir"
+
+    # Test should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$INVALID_VERSION" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Download invalid version" "Script should have failed but succeeded"
+    else
+        log_test_pass "Download invalid version"
+    fi
+}
+
+test_newer_version_when_old_exists() {
+    log_test_start "Download newer version when old version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/newer_when_old"
+    mkdir -p "$test_dir"
+
+    # Create fake old version
+    create_fake_operator_sdk_binary "$VALID_VERSION_OLD" "$test_dir/operator-sdk"
+
+    # Test should succeed and replace old version
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/operator-sdk" ]]; then
+            log_test_pass "Download newer version when old version exists"
+        else
+            log_test_fail "Download newer version when old version exists" "Binary not created"
+        fi
+    else
+        log_test_fail "Download newer version when old version exists" "Script failed"
+    fi
+}
+
+test_old_version_when_newer_exists() {
+    log_test_start "Request old version when newer version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/old_when_newer"
+    mkdir -p "$test_dir"
+
+    # Create fake newer version
+    create_fake_operator_sdk_binary "$VALID_VERSION_NEW" "$test_dir/operator-sdk"
+
+    # Test should succeed without downloading (existing version meets requirement)
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/operator-sdk" ]]; then
+            log_test_pass "Request old version when newer version exists"
+        else
+            log_test_fail "Request old version when newer version exists" "Binary not found"
+        fi
+    else
+        log_test_fail "Request old version when newer version exists" "Script failed"
+    fi
+}
+
+test_version_with_v_prefix() {
+    log_test_start "Test version with v prefix"
+
+    local test_dir="${TEST_INSTALL_DIR}/v_prefix"
+    mkdir -p "$test_dir"
+
+    # Test should succeed with v prefix
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "v$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/operator-sdk" ]]; then
+            log_test_pass "Test version with v prefix"
+        else
+            log_test_fail "Test version with v prefix" "Binary not created"
+        fi
+    else
+        log_test_fail "Test version with v prefix" "Script failed"
+    fi
+}
+
+test_help_option() {
+    log_test_start "Test help option"
+
+    # Test help option should succeed
+    if "$DOWNLOAD_SCRIPT" --help >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_pass "Test help option"
+    else
+        log_test_fail "Test help option" "Help option failed"
+    fi
+}
+
+test_invalid_option() {
+    log_test_start "Test invalid option"
+
+    # Test invalid option should fail
+    if "$DOWNLOAD_SCRIPT" --invalid-option >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test invalid option" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test invalid option"
+    fi
+}
+
+test_version_format_validation() {
+    log_test_start "Test version format validation"
+
+    local test_dir="${TEST_INSTALL_DIR}/version_format"
+    mkdir -p "$test_dir"
+
+    # Test invalid version format should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "invalid-version" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test version format validation" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test version format validation"
+    fi
+}
+
+test_missing_install_dir_argument() {
+    log_test_start "Test missing install directory argument"
+
+    # Test missing install directory argument should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test missing install directory argument" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test missing install directory argument"
+    fi
+}
+
+print_test_summary() {
+    log ""
+    log "================================================"
+    log "Test Summary:"
+    log "Total tests: $TOTAL_TESTS"
+    log "Passed: $PASSED_TESTS"
+    log "Failed: $FAILED_TESTS"
+    log "================================================"
+
+    if [[ $FAILED_TESTS -gt 0 ]]; then
+        log "${RED}Some tests failed. See $TEST_LOG_FILE for details.${NC}"
+        return 1
+    else
+        log "${GREEN}All tests passed!${NC}"
+        return 0
+    fi
+}
+
+main() {
+    log "Starting Operator SDK Download Script Tests"
+    log "==========================================="
+
+    # Check if download script exists
+    if [[ ! -f "$DOWNLOAD_SCRIPT" ]]; then
+        log "${RED}Error: Download script not found at $DOWNLOAD_SCRIPT${NC}"
+        exit 1
+    fi
+
+    setup_test_environment
+
+    # Run tests
+    test_download_valid_version
+    test_download_invalid_version
+    test_newer_version_when_old_exists
+    test_old_version_when_newer_exists
+    test_version_with_v_prefix
+    test_help_option
+    test_invalid_option
+    test_version_format_validation
+    test_missing_install_dir_argument
+
+    cleanup_test_environment
+
+    print_test_summary
+}
+
+# Run main function
+main "$@"

--- a/scripts/download/tests/test-download-opm.sh
+++ b/scripts/download/tests/test-download-opm.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+
+# Test script for download-opm.sh
+# This script tests various scenarios for the OPM download script
+
+set -eou pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test directory setup
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DOWNLOAD_SCRIPT="${SCRIPT_DIR}/../download-opm.sh"
+TEST_INSTALL_DIR="${SCRIPT_DIR}/test_bin"
+TEST_LOG_FILE="${SCRIPT_DIR}/test_results.log"
+
+# Test counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Test version constants
+VALID_VERSION_OLD="v1.50.0"
+VALID_VERSION_NEW="v1.52.0"
+INVALID_VERSION="v999.999.999"
+
+# Utility functions
+log() {
+    echo -e "$1" | tee -a "$TEST_LOG_FILE"
+}
+
+log_test_start() {
+    local test_name="$1"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log "${YELLOW}[TEST ${TOTAL_TESTS}] Starting: $test_name${NC}"
+}
+
+log_test_pass() {
+    local test_name="$1"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+    log "${GREEN}[PASS] $test_name${NC}"
+}
+
+log_test_fail() {
+    local test_name="$1"
+    local error_msg="$2"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+    log "${RED}[FAIL] $test_name${NC}"
+    log "${RED}       Error: $error_msg${NC}"
+}
+
+setup_test_environment() {
+    log "Setting up test environment..."
+
+    # Remove test directory if it exists
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+
+    # Create fresh test directory
+    mkdir -p "$TEST_INSTALL_DIR"
+
+    # Initialize log file
+    echo "OPM Download Script Test Results - $(date)" > "$TEST_LOG_FILE"
+    echo "================================================" >> "$TEST_LOG_FILE"
+}
+
+cleanup_test_environment() {
+    log "Cleaning up test environment..."
+
+    # Remove test directory
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+}
+
+create_fake_opm_binary() {
+    local version="$1"
+    local install_path="$2"
+
+    # Create fake opm binary that returns the specified version
+    cat > "$install_path" << EOF
+#!/bin/bash
+echo "opm version: $version"
+EOF
+    chmod +x "$install_path"
+}
+
+test_download_valid_version() {
+    log_test_start "Download valid version to empty directory"
+
+    local test_dir="${TEST_INSTALL_DIR}/valid_version"
+    mkdir -p "$test_dir"
+
+    # Test should succeed
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        # Check if binary was created
+        if [[ -x "$test_dir/opm" ]]; then
+            log_test_pass "Download valid version to empty directory"
+        else
+            log_test_fail "Download valid version to empty directory" "Binary not created"
+        fi
+    else
+        log_test_fail "Download valid version to empty directory" "Script failed"
+    fi
+}
+
+test_download_invalid_version() {
+    log_test_start "Download invalid version"
+
+    local test_dir="${TEST_INSTALL_DIR}/invalid_version"
+    mkdir -p "$test_dir"
+
+    # Test should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$INVALID_VERSION" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Download invalid version" "Script should have failed but succeeded"
+    else
+        log_test_pass "Download invalid version"
+    fi
+}
+
+test_newer_version_when_old_exists() {
+    log_test_start "Download newer version when old version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/newer_when_old"
+    mkdir -p "$test_dir"
+
+    # Create fake old version
+    create_fake_opm_binary "$VALID_VERSION_OLD" "$test_dir/opm"
+
+    # Test should succeed and replace old version
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/opm" ]]; then
+            log_test_pass "Download newer version when old version exists"
+        else
+            log_test_fail "Download newer version when old version exists" "Binary not created"
+        fi
+    else
+        log_test_fail "Download newer version when old version exists" "Script failed"
+    fi
+}
+
+test_old_version_when_newer_exists() {
+    log_test_start "Request old version when newer version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/old_when_newer"
+    mkdir -p "$test_dir"
+
+    # Create fake newer version
+    create_fake_opm_binary "$VALID_VERSION_NEW" "$test_dir/opm"
+
+    # Test should succeed without downloading (existing version meets requirement)
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/opm" ]]; then
+            log_test_pass "Request old version when newer version exists"
+        else
+            log_test_fail "Request old version when newer version exists" "Binary not found"
+        fi
+    else
+        log_test_fail "Request old version when newer version exists" "Script failed"
+    fi
+}
+
+test_help_option() {
+    log_test_start "Test help option"
+
+    # Test help option should succeed
+    if "$DOWNLOAD_SCRIPT" --help >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_pass "Test help option"
+    else
+        log_test_fail "Test help option" "Help option failed"
+    fi
+}
+
+test_invalid_option() {
+    log_test_start "Test invalid option"
+
+    # Test invalid option should fail
+    if "$DOWNLOAD_SCRIPT" --invalid-option >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test invalid option" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test invalid option"
+    fi
+}
+
+test_version_format_validation() {
+    log_test_start "Test version format validation"
+
+    local test_dir="${TEST_INSTALL_DIR}/version_format"
+    mkdir -p "$test_dir"
+
+    # Test invalid version format should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "invalid-version" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test version format validation" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test version format validation"
+    fi
+}
+
+test_missing_install_dir_argument() {
+    log_test_start "Test missing install directory argument"
+
+    # Test missing install directory argument should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test missing install directory argument" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test missing install directory argument"
+    fi
+}
+
+print_test_summary() {
+    log ""
+    log "================================================"
+    log "Test Summary:"
+    log "Total tests: $TOTAL_TESTS"
+    log "Passed: $PASSED_TESTS"
+    log "Failed: $FAILED_TESTS"
+    log "================================================"
+
+    if [[ $FAILED_TESTS -gt 0 ]]; then
+        log "${RED}Some tests failed. See $TEST_LOG_FILE for details.${NC}"
+        return 1
+    else
+        log "${GREEN}All tests passed!${NC}"
+        return 0
+    fi
+}
+
+main() {
+    log "Starting OPM Download Script Tests"
+    log "=================================="
+
+    # Check if download script exists
+    if [[ ! -f "$DOWNLOAD_SCRIPT" ]]; then
+        log "${RED}Error: Download script not found at $DOWNLOAD_SCRIPT${NC}"
+        exit 1
+    fi
+
+    setup_test_environment
+
+    # Run tests
+    test_download_valid_version
+    test_download_invalid_version
+    test_newer_version_when_old_exists
+    test_old_version_when_newer_exists
+    test_help_option
+    test_invalid_option
+    test_version_format_validation
+    test_missing_install_dir_argument
+
+    cleanup_test_environment
+
+    print_test_summary
+}
+
+# Run main function
+main "$@"

--- a/scripts/download/tests/test-download-yq.sh
+++ b/scripts/download/tests/test-download-yq.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+# Test script for download-yq.sh
+# This script tests various scenarios for the yq download script
+
+set -eou pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test directory setup
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DOWNLOAD_SCRIPT="${SCRIPT_DIR}/../download-yq.sh"
+TEST_INSTALL_DIR="${SCRIPT_DIR}/test_bin"
+TEST_LOG_FILE="${SCRIPT_DIR}/test_results.log"
+
+# Test counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Test version constants
+VALID_VERSION_OLD="v4.44.2"
+VALID_VERSION_NEW="v4.45.4"
+INVALID_VERSION="v999.999.999"
+
+# Utility functions
+log() {
+    echo -e "$1" | tee -a "$TEST_LOG_FILE"
+}
+
+log_test_start() {
+    local test_name="$1"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log "${YELLOW}[TEST ${TOTAL_TESTS}] Starting: $test_name${NC}"
+}
+
+log_test_pass() {
+    local test_name="$1"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+    log "${GREEN}[PASS] $test_name${NC}"
+}
+
+log_test_fail() {
+    local test_name="$1"
+    local error_msg="$2"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+    log "${RED}[FAIL] $test_name${NC}"
+    log "${RED}       Error: $error_msg${NC}"
+}
+
+setup_test_environment() {
+    log "Setting up test environment..."
+
+    # Remove test directory if it exists
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+
+    # Create fresh test directory
+    mkdir -p "$TEST_INSTALL_DIR"
+
+    # Initialize log file
+    echo "yq Download Script Test Results - $(date)" > "$TEST_LOG_FILE"
+    echo "================================================" >> "$TEST_LOG_FILE"
+}
+
+cleanup_test_environment() {
+    log "Cleaning up test environment..."
+
+    # Remove test directory
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+}
+
+create_fake_yq_binary() {
+    local version="$1"
+    local install_path="$2"
+
+    # Create fake yq binary that returns the specified version
+    cat > "$install_path" << EOF
+#!/bin/bash
+echo "yq (https://github.com/mikefarah/yq/) version $version"
+EOF
+    chmod +x "$install_path"
+}
+
+test_download_valid_version() {
+    log_test_start "Download valid version to empty directory"
+
+    local test_dir="${TEST_INSTALL_DIR}/valid_version"
+    mkdir -p "$test_dir"
+
+    # Test should succeed
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        # Check if binary was created
+        if [[ -x "$test_dir/yq" ]]; then
+            log_test_pass "Download valid version to empty directory"
+        else
+            log_test_fail "Download valid version to empty directory" "Binary not created"
+        fi
+    else
+        log_test_fail "Download valid version to empty directory" "Script failed"
+    fi
+}
+
+test_download_invalid_version() {
+    log_test_start "Download invalid version"
+
+    local test_dir="${TEST_INSTALL_DIR}/invalid_version"
+    mkdir -p "$test_dir"
+
+    # Test should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$INVALID_VERSION" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Download invalid version" "Script should have failed but succeeded"
+    else
+        log_test_pass "Download invalid version"
+    fi
+}
+
+test_newer_version_when_old_exists() {
+    log_test_start "Download newer version when old version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/newer_when_old"
+    mkdir -p "$test_dir"
+
+    # Create fake old version
+    create_fake_yq_binary "$VALID_VERSION_OLD" "$test_dir/yq"
+
+    # Test should succeed and replace old version
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/yq" ]]; then
+            log_test_pass "Download newer version when old version exists"
+        else
+            log_test_fail "Download newer version when old version exists" "Binary not created"
+        fi
+    else
+        log_test_fail "Download newer version when old version exists" "Script failed"
+    fi
+}
+
+test_old_version_when_newer_exists() {
+    log_test_start "Request old version when newer version exists"
+
+    local test_dir="${TEST_INSTALL_DIR}/old_when_newer"
+    mkdir -p "$test_dir"
+
+    # Create fake newer version
+    create_fake_yq_binary "$VALID_VERSION_NEW" "$test_dir/yq"
+
+    # Test should succeed without downloading (existing version meets requirement)
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
+        if [[ -x "$test_dir/yq" ]]; then
+            log_test_pass "Request old version when newer version exists"
+        else
+            log_test_fail "Request old version when newer version exists" "Binary not found"
+        fi
+    else
+        log_test_fail "Request old version when newer version exists" "Script failed"
+    fi
+}
+
+test_version_without_v_prefix() {
+    log_test_start "Test version without v prefix"
+
+    local test_dir="${TEST_INSTALL_DIR}/no_v_prefix"
+    mkdir -p "$test_dir"
+
+    # Test should succeed without v prefix (script should add it)
+    local version_no_v="${VALID_VERSION_NEW#v}"
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$version_no_v" >> "$TEST_LOG_FILE" 2>&1; then
+        # Check if binary was created
+        if [[ -x "$test_dir/yq" ]]; then
+            log_test_pass "Test version without v prefix"
+        else
+            log_test_fail "Test version without v prefix" "Binary not created"
+        fi
+    else
+        log_test_fail "Test version without v prefix" "Script failed"
+    fi
+}
+
+test_help_option() {
+    log_test_start "Test help option"
+
+    # Test help option should succeed
+    if "$DOWNLOAD_SCRIPT" --help >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_pass "Test help option"
+    else
+        log_test_fail "Test help option" "Help option failed"
+    fi
+}
+
+test_invalid_option() {
+    log_test_start "Test invalid option"
+
+    # Test invalid option should fail
+    if "$DOWNLOAD_SCRIPT" --invalid-option >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test invalid option" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test invalid option"
+    fi
+}
+
+test_version_format_validation() {
+    log_test_start "Test version format validation"
+
+    local test_dir="${TEST_INSTALL_DIR}/version_format"
+    mkdir -p "$test_dir"
+
+    # Test invalid version format should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "invalid-version" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test version format validation" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test version format validation"
+    fi
+}
+
+test_missing_install_dir_argument() {
+    log_test_start "Test missing install directory argument"
+
+    # Test missing install directory argument should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Test missing install directory argument" "Script should have failed but succeeded"
+    else
+        log_test_pass "Test missing install directory argument"
+    fi
+}
+
+print_test_summary() {
+    log ""
+    log "================================================"
+    log "Test Summary:"
+    log "Total tests: $TOTAL_TESTS"
+    log "Passed: $PASSED_TESTS"
+    log "Failed: $FAILED_TESTS"
+    log "================================================"
+
+    if [[ $FAILED_TESTS -gt 0 ]]; then
+        log "${RED}Some tests failed. See $TEST_LOG_FILE for details.${NC}"
+        return 1
+    else
+        log "${GREEN}All tests passed!${NC}"
+        return 0
+    fi
+}
+
+main() {
+    log "Starting yq Download Script Tests"
+    log "================================="
+
+    # Check if download script exists
+    if [[ ! -f "$DOWNLOAD_SCRIPT" ]]; then
+        log "${RED}Error: Download script not found at $DOWNLOAD_SCRIPT${NC}"
+        exit 1
+    fi
+
+    setup_test_environment
+
+    # Run tests
+    test_download_valid_version
+    test_download_invalid_version
+    test_newer_version_when_old_exists
+    test_old_version_when_newer_exists
+    test_version_without_v_prefix
+    test_help_option
+    test_invalid_option
+    test_version_format_validation
+    test_missing_install_dir_argument
+
+    cleanup_test_environment
+
+    print_test_summary
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
- Update catalog targets to not implicitly invoke opm validate as part of the catalog generation. This is important because the operators need to do some extra modifications on top before validating.
- Update the operator-sdk script to download from the upstream github release instead of the outdated openshift mirror. This is required because we need newer versions of the tool.
- Update all the download tool scripts to move the logic to check for tool presence into the script. This is useful because now the operators don't need to duplicate all this logic.
- Update all the download tool scripts to download the tool if the available version is oudated. This ensures the minimum version will be available.
- Create tests for all the download tool scripts
- Create makefile target to run all the download tool tests
- Update the documentation to cover the operator-sdk changes
- Create a README in the catalog folder describing how to use the compare catalog script
- Create a new github action to run the download tool tests