### PR TITLE
Update names on the makefile workflows so they are less confusing

### DIFF
--- a/.github/workflows/make-all.yaml
+++ b/.github/workflows/make-all.yaml
@@ -1,5 +1,5 @@
 ---
-name: Makefile CI
+name: Makefile (make all)
 
 "on":
   push:

--- a/.github/workflows/make-test-download-scripts.yaml
+++ b/.github/workflows/make-test-download-scripts.yaml
@@ -1,5 +1,5 @@
 ---
-name: Makefile CI
+name: Makefile (test download scripts)
 
 "on":
   push:

--- a/.github/workflows/make-test-overlay.yaml
+++ b/.github/workflows/make-test-overlay.yaml
@@ -1,5 +1,5 @@
 ---
-name: Test Overlay CI
+name: Makefile (test overlay script)
 
 "on":
   push:


### PR DESCRIPTION
Both the `make all` and the download scripts workflows were called "Makefile CI" which was a bit confusing
