### PR TITLE
Remove references to obsolete loopback plugin

### DIFF
--- a/test/overlay/ocloud/4.20/00.data/expected/oran-o2ims.clusterserviceversion.yaml
+++ b/test/overlay/ocloud/4.20/00.data/expected/oran-o2ims.clusterserviceversion.yaml
@@ -1854,8 +1854,6 @@ spec:
                         value: registry.redhat.io/rhel9/postgresql-16@sha256:4f46bed6bce211be83c110a3452bd3f151a1e8ab150c58f2a02c56e9cc83db98
                       - name: HWMGR_PLUGIN_NAMESPACE
                         value: oran-o2ims
-                      - name: DEPLOY_LOOPBACK_HW_PLUGIN
-                        value: "false"
                       - name: OCLOUD_MANAGER_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/test/overlay/ocloud/4.20/00.data/oran-o2ims.clusterserviceversion.in.yaml
+++ b/test/overlay/ocloud/4.20/00.data/oran-o2ims.clusterserviceversion.in.yaml
@@ -1860,8 +1860,6 @@ spec:
                         value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
                       - name: HWMGR_PLUGIN_NAMESPACE
                         value: oran-o2ims
-                      - name: DEPLOY_LOOPBACK_HW_PLUGIN
-                        value: "false"
                       - name: OCLOUD_MANAGER_NAMESPACE
                         valueFrom:
                           fieldRef:


### PR DESCRIPTION
The loopback plugin has been removed from the O-RAN repo. 
This update removes references to the loopback plugin.