### PR TITLE
Update download scripts to always download the specified version to the install directory

### DIFF
--- a/.github/workflows/make-test-download-scripts.yaml
+++ b/.github/workflows/make-test-download-scripts.yaml
@@ -12,15 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Remove local jq as it interferes with the test
-        run: sudo apt-get remove -y jq
-      - name: Remove local yq as it interferes with the test
-        run: sudo rm -f $(which yq)
-      - name: Remove local yamllint as it interferes with the test
-        run: sudo rm -f $(which yamllint)
-      - name: Remove local shellcheck as it interferes with the test
-        run: sudo rm -f $(which shellcheck)
-      - name: Install xz as it is required by the test
+      - name: Install xz as it is required to unzip the shellcheck binary
         run: sudo apt-get install -y xz-utils
       - name: Run make test locally for the download scripts
         run: make -C scripts/download test-local || (cat scripts/download/tests/test_results.log && exit 1)

--- a/scripts/download/download-golangci-lint.sh
+++ b/scripts/download/download-golangci-lint.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 # This script automates the download and installation of golangci-lint, a fast linters runner for Go.
-# It first checks if golangci-lint is available in the system PATH or local install directory.
-# If found, it compares the version to ensure it meets the minimum requirement.
-# It only downloads if no suitable version is found.
+# It checks if golangci-lint is available in the local install directory with the exact required version.
+# It downloads and installs golangci-lint to the local directory if not found or if the version
+# doesn't exactly match the specified version. If an existing binary can't execute
+# (e.g., wrong architecture/OS), it will be automatically replaced.
 
 # Configure shell to exit immediately if a command exits with a non-zero status,
 # treat unset variables as an error, and fail a pipeline if any command fails.
@@ -26,11 +27,11 @@ usage() {
 Usage: $0 [OPTIONS] [VERSION]
 
 Downloads and installs golangci-lint, a fast linters runner for Go, if necessary.
-Checks system PATH and local install directory first, and only downloads
-if the existing version doesn't meet the minimum requirement.
+Checks local install directory first, and only downloads if the existing
+version doesn't exactly match the specified version.
 
 Arguments:
-    VERSION               Minimum version required (default: ${DEFAULT_VERSION})
+    VERSION              Exact version required (default: ${DEFAULT_VERSION})
                          Format: vX.Y.Z (e.g., v1.57.0)
 
 Options:
@@ -41,8 +42,8 @@ Environment Variables:
     INSTALL_DIR           Install directory (overridden by -d/--install-dir)
 
 Examples:
-    $0                                    # Ensure default version is available
-    $0 v1.55.0                           # Ensure minimum version v1.55.0 is available
+    $0                                   # Ensure default version is available
+    $0 v1.55.0                           # Ensure exact version v1.55.0 is available locally
     $0 -d /usr/local/bin v1.55.0         # Install to custom directory if needed
     $0 --install-dir /tmp/tools          # Install to custom directory if needed
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
@@ -51,9 +52,9 @@ Examples:
 EOF
 }
 
-# Function to compare version strings
-# Returns 0 if version1 >= version2, 1 otherwise
-version_compare() {
+# Function to check if two version strings are exactly equal
+# Returns 0 if version1 == version2, 1 otherwise
+version_exact_match() {
     local version1="$1"
     local version2="$2"
 
@@ -61,11 +62,11 @@ version_compare() {
     version1="${version1#v}"
     version2="${version2#v}"
 
-    # Use sort -V to compare versions
-    if [[ "$(printf '%s\n' "$version1" "$version2" | sort -V | head -n1)" == "$version2" ]]; then
-        return 0  # version1 >= version2
+    # Check for exact match
+    if [[ "$version1" == "$version2" ]]; then
+        return 0  # versions match exactly
     else
-        return 1  # version1 < version2
+        return 1  # versions don't match
     fi
 }
 
@@ -135,29 +136,7 @@ main() {
     # Define the full path where the golangci-lint binary will be saved.
     local install_path="${install_dir}/golangci-lint"
 
-    echo "Checking for golangci-lint with minimum version ${version}..."
-
-    # Check if golangci-lint is available in system PATH
-    local system_binary=""
-    if system_binary=$(command -v golangci-lint 2>/dev/null); then
-        echo "Found golangci-lint in system PATH: $system_binary"
-
-        local system_version
-        if system_version=$(get_golangci_lint_version "$system_binary"); then
-            echo "System golangci-lint version: $system_version"
-
-            if version_compare "$system_version" "$version"; then
-                echo "System golangci-lint version $system_version meets minimum requirement $version"
-                return 0
-            else
-                echo "System golangci-lint version $system_version is below minimum requirement $version"
-            fi
-        else
-            echo "Could not determine system golangci-lint version"
-        fi
-    else
-        echo "golangci-lint not found in system PATH"
-    fi
+    echo "Checking for golangci-lint with exact version ${version} in local install directory..."
 
     # Check if golangci-lint exists in local install directory
     if [[ -x "$install_path" ]]; then
@@ -167,11 +146,11 @@ main() {
         if local_version=$(get_golangci_lint_version "$install_path"); then
             echo "Local golangci-lint version: $local_version"
 
-            if version_compare "$local_version" "$version"; then
-                echo "Local golangci-lint version $local_version meets minimum requirement $version"
+            if version_exact_match "$local_version" "$version"; then
+                echo "Local golangci-lint version $local_version matches required version $version"
                 return 0
             else
-                echo "Local golangci-lint version $local_version is below minimum requirement $version"
+                echo "Local golangci-lint version $local_version does not match required version $version"
             fi
         else
             echo "Could not determine local golangci-lint version"
@@ -180,7 +159,7 @@ main() {
         echo "golangci-lint not found in local install directory: $install_path"
     fi
 
-    # No suitable version found, proceed with download
+    # No exact version match found, proceed with download
     echo "Downloading golangci-lint ${version}..."
 
     # Detect the system's machine architecture (e.g., x86_64, arm64, aarch64).

--- a/scripts/download/download-jq.sh
+++ b/scripts/download/download-jq.sh
@@ -2,8 +2,10 @@
 
 # This script automates the download and installation of jq, a lightweight and
 # flexible command-line JSON processor.
-# It checks if jq is already installed and, if not, fetches the correct binary
-# for the system's architecture and operating system from the official GitHub releases.
+# It checks if jq is available in the local install directory with the exact required version.
+# It downloads and installs jq to the local directory if not found or if the version
+# doesn't exactly match the specified version. If an existing binary can't execute
+# (e.g., wrong architecture/OS), it will be automatically replaced.
 
 set -eou pipefail
 
@@ -22,9 +24,11 @@ usage() {
 Usage: $0 [OPTIONS] [VERSION]
 
 Downloads and installs jq, a command-line JSON processor.
+Checks local install directory first, and only downloads if the existing
+version doesn't exactly match the specified version.
 
 Arguments:
-    VERSION               Version to install (default: ${DEFAULT_VERSION})
+    VERSION              Exact version required (default: ${DEFAULT_VERSION})
                          Format: X.Y.Z (e.g., 1.7.1)
 
 Options:
@@ -35,14 +39,45 @@ Environment Variables:
     INSTALL_DIR           Install directory (overridden by -d/--install-dir)
 
 Examples:
-    $0                                   # Install default version to default directory
-    $0 1.6                               # Install specific version to default directory
+    $0                                   # Ensure default version is available locally
+    $0 1.6                               # Ensure exact version 1.6 is available locally
     $0 -d /usr/local/bin 1.6             # Install specific version to custom directory
     $0 --install-dir /tmp/tools          # Install default version to custom directory
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
     $0 --help                            # Show help
 
 EOF
+}
+
+# Function to check if two version strings are exactly equal
+# Returns 0 if version1 == version2, 1 otherwise
+version_exact_match() {
+    local version1="$1"
+    local version2="$2"
+
+    # Remove 'v' prefix if present
+    version1="${version1#v}"
+    version2="${version2#v}"
+
+    # Check for exact match
+    if [[ "$version1" == "$version2" ]]; then
+        return 0  # versions match exactly
+    else
+        return 1  # versions don't match
+    fi
+}
+
+# Function to get jq version from a binary path
+get_jq_version() {
+    local binary_path="$1"
+
+    if [[ -x "$binary_path" ]]; then
+        # Try to get version, extract just the version number
+        local version_output
+        if version_output=$(bash -c "$binary_path --version" 2>/dev/null); then
+            echo "$version_output" | grep -o '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*' | head -1
+        fi
+    fi
 }
 
 main() {
@@ -80,83 +115,103 @@ main() {
     # Define the full path where the jq binary will be saved.
     local install_path="${install_dir}/jq"
 
-    # Check if jq is not already available in the system's PATH.
-    if ! which jq > /dev/null 2>&1; then
-        echo "Downloading jq tool"
-        arch=$(uname -m)
-        os=$(uname)
+    echo "Checking for jq with exact version ${version} in local install directory..."
 
-        # Normalize architecture to the values used by the jq github page
-        if [[ "${arch}" == "x86_64" ]]; then
-            arch="amd64"
-            echo "Normalizing architecture to '${arch}'"
-        elif [[ "${arch}" == "aarch64" ]]; then
-            arch="arm64"
-            echo "Normalizing architecture to '${arch}'"
-        fi
+    # Check if jq exists in local install directory
+    if [[ -x "$install_path" ]]; then
+        echo "Found jq in local install directory: $install_path"
 
-        # Normalize os name to the values used by the jq github page
-        if [[ "${os}" == "Darwin" ]]; then
-            os="macos"
-            echo "Normalizing os name to '${os}'"
-        elif [[ "${os}" == "Linux" ]]; then
-            os="linux"
-            echo "Normalizing os name to '${os}'"
-        fi
+        local local_version
+        if local_version=$(get_jq_version "$install_path"); then
+            echo "Local jq version: $local_version"
 
-        # Create install directory
-        echo "Creating directory '${install_dir}'"
-        mkdir -p "${install_dir}"
-
-        # Download binary
-        url="https://github.com/jqlang/jq/releases/download/jq-${version}/jq-${os}-${arch}"
-        echo "Fetching jq version ${version} with url '${url}'"
-        # Download with error handling
-        local http_code
-        http_code=$(curl -L -s -o "${install_path}" --write-out "%{http_code}" "${url}" 2>/dev/null)
-        local curl_exit_code=$?
-
-        if [[ $curl_exit_code -ne 0 ]]; then
-            echo "ERROR: Failed to download jq version ${version} (curl failed with exit code ${curl_exit_code})"
-            exit 1
-        fi
-
-        if [[ "$http_code" -ne 200 ]]; then
-            if [[ "$http_code" -eq 404 ]]; then
-                echo "ERROR: jq version ${version} not found for ${os}/${arch}"
-                echo "Available versions can be found at: https://github.com/jqlang/jq/releases"
+            if version_exact_match "$local_version" "$version"; then
+                echo "Local jq version $local_version matches required version $version"
+                return 0
             else
-                echo "ERROR: Failed to download jq version ${version} (HTTP ${http_code})"
+                echo "Local jq version $local_version does not match required version $version"
             fi
-            exit 1
+        else
+            echo "Could not determine local jq version"
         fi
-
-        # Verify the downloaded file is not empty
-        if [[ ! -s "${install_path}" ]]; then
-            echo "ERROR: Downloaded file is empty"
-            exit 1
-        fi
-
-        # Check if the file starts with common error messages
-        local first_line
-        first_line=$(head -n 1 "${install_path}" 2>/dev/null || echo "")
-        if [[ "$first_line" =~ ^[[:space:]]*(Not[[:space:]]+Found|404|Error|<html|<HTML) ]]; then
-            echo "ERROR: Downloaded file appears to be an error message, not a binary"
-            echo "First line: $first_line"
-            exit 1
-        fi
-
-        chmod +x "${install_path}"
-
-        # Verify the installation was successful
-        if ! bash -c "${install_path} --version | grep '${version}'"; then
-            echo "ERROR: Failed to install jq. Version check failed."
-            exit 1
-        fi
-        echo "jq version ${version} installed successfully to ${install_path}"
     else
-        echo "jq is already installed at: $(which jq)"
+        echo "jq not found in local install directory: $install_path"
     fi
+
+    # No exact version match found, proceed with download
+    echo "Downloading jq ${version}..."
+
+    arch=$(uname -m)
+    os=$(uname)
+
+    # Normalize architecture to the values used by the jq github page
+    if [[ "${arch}" == "x86_64" ]]; then
+        arch="amd64"
+        echo "Normalizing architecture to '${arch}'"
+    elif [[ "${arch}" == "aarch64" ]]; then
+        arch="arm64"
+        echo "Normalizing architecture to '${arch}'"
+    fi
+
+    # Normalize os name to the values used by the jq github page
+    if [[ "${os}" == "Darwin" ]]; then
+        os="macos"
+        echo "Normalizing os name to '${os}'"
+    elif [[ "${os}" == "Linux" ]]; then
+        os="linux"
+        echo "Normalizing os name to '${os}'"
+    fi
+
+    # Create install directory
+    echo "Creating directory '${install_dir}'"
+    mkdir -p "${install_dir}"
+
+    # Download binary
+    url="https://github.com/jqlang/jq/releases/download/jq-${version}/jq-${os}-${arch}"
+    echo "Fetching jq version ${version} with url '${url}'"
+    # Download with error handling
+    local http_code
+    http_code=$(curl -L -s -o "${install_path}" --write-out "%{http_code}" "${url}" 2>/dev/null)
+    local curl_exit_code=$?
+
+    if [[ $curl_exit_code -ne 0 ]]; then
+        echo "ERROR: Failed to download jq version ${version} (curl failed with exit code ${curl_exit_code})"
+        exit 1
+    fi
+
+    if [[ "$http_code" -ne 200 ]]; then
+        if [[ "$http_code" -eq 404 ]]; then
+            echo "ERROR: jq version ${version} not found for ${os}/${arch}"
+            echo "Available versions can be found at: https://github.com/jqlang/jq/releases"
+        else
+            echo "ERROR: Failed to download jq version ${version} (HTTP ${http_code})"
+        fi
+        exit 1
+    fi
+
+    # Verify the downloaded file is not empty
+    if [[ ! -s "${install_path}" ]]; then
+        echo "ERROR: Downloaded file is empty"
+        exit 1
+    fi
+
+    # Check if the file starts with common error messages
+    local first_line
+    first_line=$(head -n 1 "${install_path}" 2>/dev/null || echo "")
+    if [[ "$first_line" =~ ^[[:space:]]*(Not[[:space:]]+Found|404|Error|<html|<HTML) ]]; then
+        echo "ERROR: Downloaded file appears to be an error message, not a binary"
+        echo "First line: $first_line"
+        exit 1
+    fi
+
+    chmod +x "${install_path}"
+
+    # Verify the installation was successful
+    if ! bash -c "${install_path} --version | grep '${version}'"; then
+        echo "ERROR: Failed to install jq. Version check failed."
+        exit 1
+    fi
+    echo "jq version ${version} installed successfully to ${install_path}"
 }
 
 # Execute the main function, passing along any script arguments.

--- a/scripts/download/download-opm.sh
+++ b/scripts/download/download-opm.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 # This script automates the download and installation of opm (Operator Package Manager).
-# It first checks if opm is available in the system PATH or local install directory.
-# If found, it compares the version to ensure it meets the minimum requirement.
-# It only downloads if no suitable version is found.
+# It checks if opm is available in the local install directory with the exact required version.
+# It downloads and installs opm to the local directory if not found or if the version
+# doesn't exactly match the specified version. If an existing binary can't execute
+# (e.g., wrong architecture/OS), it will be automatically replaced.
 
 # Configure shell to exit immediately if a command exits with a non-zero status,
 # treat unset variables as an error, and fail a pipeline if any command fails.
@@ -26,11 +27,11 @@ usage() {
 Usage: $0 [OPTIONS] [VERSION]
 
 Downloads and installs opm (Operator Package Manager) if necessary.
-Checks system PATH and local install directory first, and only downloads
-if the existing version doesn't meet the minimum requirement.
+Checks local install directory first, and only downloads if the existing
+version doesn't exactly match the specified version.
 
 Arguments:
-    VERSION               Minimum version required (default: ${DEFAULT_VERSION})
+    VERSION              Exact version required (default: ${DEFAULT_VERSION})
                          Format: vX.Y.Z (e.g., v1.52.0)
 
 Options:
@@ -41,8 +42,8 @@ Environment Variables:
     INSTALL_DIR           Install directory (overridden by -d/--install-dir)
 
 Examples:
-    $0                                    # Ensure default version is available
-    $0 v1.51.0                           # Ensure minimum version v1.51.0 is available
+    $0                                   # Ensure default version is available locally
+    $0 v1.51.0                           # Ensure exact version v1.51.0 is available locally
     $0 -d /usr/local/bin v1.51.0         # Install to custom directory if needed
     $0 --install-dir /tmp/tools          # Install to custom directory if needed
     INSTALL_DIR=/opt/bin $0              # Install using environment variable
@@ -51,9 +52,9 @@ Examples:
 EOF
 }
 
-# Function to compare version strings
-# Returns 0 if version1 >= version2, 1 otherwise
-version_compare() {
+# Function to check if two version strings are exactly equal
+# Returns 0 if version1 == version2, 1 otherwise
+version_exact_match() {
     local version1="$1"
     local version2="$2"
 
@@ -61,11 +62,11 @@ version_compare() {
     version1="${version1#v}"
     version2="${version2#v}"
 
-    # Use sort -V to compare versions
-    if [[ "$(printf '%s\n' "$version1" "$version2" | sort -V | head -n1)" == "$version2" ]]; then
-        return 0  # version1 >= version2
+    # Check for exact match
+    if [[ "$version1" == "$version2" ]]; then
+        return 0  # versions match exactly
     else
-        return 1  # version1 < version2
+        return 1  # versions don't match
     fi
 }
 
@@ -128,29 +129,7 @@ main() {
     # Define the full path where the opm binary will be saved.
     local install_path="${install_dir}/opm"
 
-    echo "Checking for opm with minimum version ${version}..."
-
-    # Check if opm is available in system PATH
-    local system_binary=""
-    if system_binary=$(command -v opm 2>/dev/null); then
-        echo "Found opm in system PATH: $system_binary"
-
-        local system_version
-        if system_version=$(get_opm_version "$system_binary"); then
-            echo "System opm version: $system_version"
-
-            if version_compare "$system_version" "$version"; then
-                echo "System opm version $system_version meets minimum requirement $version"
-                return 0
-            else
-                echo "System opm version $system_version is below minimum requirement $version"
-            fi
-        else
-            echo "Could not determine system opm version"
-        fi
-    else
-        echo "opm not found in system PATH"
-    fi
+    echo "Checking for opm with exact version ${version} in local install directory..."
 
     # Check if opm exists in local install directory
     if [[ -x "$install_path" ]]; then
@@ -160,11 +139,11 @@ main() {
         if local_version=$(get_opm_version "$install_path"); then
             echo "Local opm version: $local_version"
 
-            if version_compare "$local_version" "$version"; then
-                echo "Local opm version $local_version meets minimum requirement $version"
+            if version_exact_match "$local_version" "$version"; then
+                echo "Local opm version $local_version matches required version $version"
                 return 0
             else
-                echo "Local opm version $local_version is below minimum requirement $version"
+                echo "Local opm version $local_version does not match required version $version"
             fi
         else
             echo "Could not determine local opm version"
@@ -173,7 +152,7 @@ main() {
         echo "opm not found in local install directory: $install_path"
     fi
 
-    # No suitable version found, proceed with download
+    # No exact version match found, proceed with download
     echo "Downloading opm ${version}..."
 
     # Detect the system's machine architecture (e.g., x86_64, arm64, aarch64).

--- a/scripts/download/tests/test-download-bashate.sh
+++ b/scripts/download/tests/test-download-bashate.sh
@@ -32,37 +32,57 @@ log() {
     echo -e "$1" | tee -a "$TEST_LOG_FILE"
 }
 
-run_test() {
+log_test_start() {
     local test_name="$1"
-    local test_command="$2"
-    local expected_exit_code="${3:-0}"
-
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log "${YELLOW}[TEST ${TOTAL_TESTS}] Starting: $test_name${NC}"
+}
 
-    log "\n${YELLOW}[TEST $TOTAL_TESTS]${NC} $test_name"
-    log "Command: $test_command"
+log_test_pass() {
+    local test_name="$1"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+    log "${GREEN}[PASS] $test_name${NC}"
+}
 
-    # Clean up test directory before each test
-    rm -rf "$TEST_INSTALL_DIR"
+log_test_fail() {
+    local test_name="$1"
+    local error_msg="$2"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+    log "${RED}[FAIL] $test_name${NC}"
+    log "${RED}       Error: $error_msg${NC}"
+}
+
+setup_test_environment() {
+    log "Setting up test environment..."
+
+    # Remove test directory if it exists
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+
+    # Create fresh test directory
     mkdir -p "$TEST_INSTALL_DIR"
 
-    # Run the test command
-    if eval "$test_command" >> "$TEST_LOG_FILE" 2>&1; then
-        actual_exit_code=0
-    else
-        actual_exit_code=$?
-    fi
+    # Initialize log file
+    echo "bashate Download Script Test Results - $(date)" > "$TEST_LOG_FILE"
+    echo "================================================" >> "$TEST_LOG_FILE"
+}
 
-    # Check if exit code matches expected
-    if [[ $actual_exit_code -eq $expected_exit_code ]]; then
-        log "${GREEN}✓ PASSED${NC}"
-        PASSED_TESTS=$((PASSED_TESTS + 1))
-        return 0
-    else
-        log "${RED}✗ FAILED${NC} (Expected exit code: $expected_exit_code, Actual: $actual_exit_code)"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
+cleanup_test_environment() {
+    log "Cleaning up test environment..."
+
+    # Remove test directory
+    if [[ -d "$TEST_INSTALL_DIR" ]]; then
+        rm -rf "$TEST_INSTALL_DIR"
+    fi
+}
+
+check_python() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        log_test_fail "Python check" "python3 is not available. Please install Python 3 to run bashate tests."
         return 1
     fi
+    return 0
 }
 
 verify_installation() {
@@ -71,183 +91,171 @@ verify_installation() {
     local venv_path="$3"
 
     if [[ ! -x "$binary_path" ]]; then
-        log "Binary not found or not executable: $binary_path"
         return 1
     fi
 
     if [[ ! -d "$venv_path" ]]; then
-        log "Virtual environment directory not found: $venv_path"
         return 1
     fi
 
     local actual_version
     if ! actual_version=$("$binary_path" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1); then
-        log "Failed to get version from $binary_path"
         return 1
     fi
 
     if [[ "$actual_version" == "$expected_version" ]]; then
-        log "Version verification passed: $actual_version"
-        log "Virtual environment verified: $venv_path"
         return 0
     else
-        log "Version mismatch. Expected: $expected_version, Actual: $actual_version"
         return 1
     fi
 }
 
-check_python() {
-    if ! command -v python3 >/dev/null 2>&1; then
-        log "${YELLOW}Warning: Python 3 not found. Some tests may fail.${NC}"
+test_help_message() {
+    log_test_start "Help message display"
+
+    local test_dir="${TEST_INSTALL_DIR}/help_test"
+    mkdir -p "$test_dir"
+
+    if "$DOWNLOAD_SCRIPT" --help >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_pass "Help message display"
+        return 0
+    else
+        log_test_fail "Help message display" "Help command failed"
         return 1
     fi
-    return 0
 }
 
-# Initialize test log
-echo "bashate Download Script Test Results" > "$TEST_LOG_FILE"
-echo "Test started at: $(date)" >> "$TEST_LOG_FILE"
-echo "========================================" >> "$TEST_LOG_FILE"
+test_download_valid_version() {
+    log_test_start "Download valid version to empty directory"
 
-log "${YELLOW}Starting bashate download script tests...${NC}"
+    local test_dir="${TEST_INSTALL_DIR}/valid_version"
+    mkdir -p "$test_dir"
 
-# Check Python availability
-if ! check_python; then
-    log "${RED}Python 3 is required for bashate installation. Skipping tests.${NC}"
-    exit 1
-fi
-
-# Test 1: Help message
-run_test "Help message display" \
-    "'$DOWNLOAD_SCRIPT' --help"
-
-# Test 2: Download with default version
-run_test "Download default version" \
-    "'$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR'"
-
-if [[ $? -eq 0 ]]; then
-    # Verify the installation
-    if verify_installation "$TEST_INSTALL_DIR/bashate" "2.1.1" "$TEST_INSTALL_DIR/.bashate-venv"; then
-        log "${GREEN}Installation verification passed${NC}"
+    # Test should succeed
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        # Check if binary was created and has correct version
+        if verify_installation "$test_dir/bashate" "$VALID_VERSION_NEW" "$test_dir/.bashate-venv"; then
+            log_test_pass "Download valid version to empty directory"
+            return 0
+        else
+            log_test_fail "Download valid version to empty directory" "Installation verification failed"
+            return 1
+        fi
     else
-        log "${RED}Installation verification failed${NC}"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
+        log_test_fail "Download valid version to empty directory" "Download command failed"
+        return 1
     fi
-fi
+}
 
-# Test 3: Download specific older version
-run_test "Download specific version ($VALID_VERSION_OLD)" \
-    "'$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR' '$VALID_VERSION_OLD'"
+test_download_invalid_version() {
+    log_test_start "Download invalid version (should fail)"
 
-if [[ $? -eq 0 ]]; then
-    if verify_installation "$TEST_INSTALL_DIR/bashate" "$VALID_VERSION_OLD" "$TEST_INSTALL_DIR/.bashate-venv"; then
-        log "${GREEN}Installation verification passed${NC}"
+    local test_dir="${TEST_INSTALL_DIR}/invalid_version"
+    mkdir -p "$test_dir"
+
+    # Test should fail
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$INVALID_VERSION" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Download invalid version (should fail)" "Command succeeded when it should have failed"
+        return 1
     else
-        log "${RED}Installation verification failed${NC}"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
+        log_test_pass "Download invalid version (should fail)"
+        return 0
     fi
-fi
+}
 
-# Test 4: Download with force flag (should reinstall)
-run_test "Force reinstall" \
-    "'$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR' --force '$VALID_VERSION_NEW'"
+test_reinstall_same_version() {
+    log_test_start "Reinstall same version"
 
-if [[ $? -eq 0 ]]; then
-    if verify_installation "$TEST_INSTALL_DIR/bashate" "$VALID_VERSION_NEW" "$TEST_INSTALL_DIR/.bashate-venv"; then
-        log "${GREEN}Force installation verification passed${NC}"
-    else
-        log "${RED}Force installation verification failed${NC}"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
-    fi
-fi
+    local test_dir="${TEST_INSTALL_DIR}/reinstall_same"
+    mkdir -p "$test_dir"
 
-# Test 5: Skip download if compatible version exists
-TOTAL_TESTS=$((TOTAL_TESTS + 1))
-
-log "\n${YELLOW}[TEST $TOTAL_TESTS]${NC} Skip download for existing compatible version"
-log "Command: '$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR' '$VALID_VERSION_OLD'"
-
-# Run the test command without cleaning up the directory first
-# This should skip installation since Test 4 installed a newer version (2.1.1) and we're requesting an older one (2.1.0)
-if "$DOWNLOAD_SCRIPT" --install-dir "$TEST_INSTALL_DIR" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
-    actual_exit_code=0
-else
-    actual_exit_code=$?
-fi
-
-# Check if exit code matches expected (0)
-if [[ $actual_exit_code -eq 0 ]]; then
-    log "${GREEN}✓ PASSED${NC}"
-    PASSED_TESTS=$((PASSED_TESTS + 1))
-
-    # Verify that it actually skipped installation by checking if the output contains the skip message
-    if tail -n 10 "$TEST_LOG_FILE" | grep -q "is already installed.*and meets the required version"; then
-        log "${GREEN}Successfully skipped installation for compatible version${NC}"
-    else
-        log "${YELLOW}Warning: Installation may not have been skipped as expected${NC}"
-    fi
-else
-    log "${RED}✗ FAILED${NC} (Expected exit code: 0, Actual: $actual_exit_code)"
-    FAILED_TESTS=$((FAILED_TESTS + 1))
-fi
-
-# Test 6: Invalid version format
-run_test "Invalid version format" \
-    "'$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR' 'invalid-version'" 1
-
-# Test 7: Non-existent version (should fail)
-run_test "Non-existent version" \
-    "'$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR' '$INVALID_VERSION'" 1
-
-# Test 8: Invalid option
-run_test "Invalid command line option" \
-    "'$DOWNLOAD_SCRIPT' --invalid-option" 1
-
-# Test 9: Verbose mode
-run_test "Verbose mode" \
-    "'$DOWNLOAD_SCRIPT' --install-dir '$TEST_INSTALL_DIR' --verbose --force '$VALID_VERSION_NEW'"
-
-# Test 10: Test wrapper script functionality
-if [[ -x "$TEST_INSTALL_DIR/bashate" && -d "$TEST_INSTALL_DIR/.bashate-venv" ]]; then
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-
-    log "\n${YELLOW}[TEST $TOTAL_TESTS]${NC} Wrapper script execution test"
-    log "Command: '$TEST_INSTALL_DIR/bashate' --help"
-
-    # Run the test command without cleaning up the directory first
-    if "$TEST_INSTALL_DIR/bashate" --help >> "$TEST_LOG_FILE" 2>&1; then
-        actual_exit_code=0
-    else
-        actual_exit_code=$?
+    # First install
+    if ! "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Reinstall same version" "First installation failed"
+        return 1
     fi
 
-    # Check if exit code matches expected (0)
-    if [[ $actual_exit_code -eq 0 ]]; then
-        log "${GREEN}✓ PASSED${NC}"
-        PASSED_TESTS=$((PASSED_TESTS + 1))
+    # Second install of same version - should reinstall
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        if verify_installation "$test_dir/bashate" "$VALID_VERSION_NEW" "$test_dir/.bashate-venv"; then
+            log_test_pass "Reinstall same version"
+            return 0
+        else
+            log_test_fail "Reinstall same version" "Second installation verification failed"
+            return 1
+        fi
     else
-        log "${RED}✗ FAILED${NC} (Expected exit code: 0, Actual: $actual_exit_code)"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
+        log_test_fail "Reinstall same version" "Second installation failed"
+        return 1
     fi
-fi
+}
 
-# Clean up test directory
-log "\n${YELLOW}Cleaning up test directory...${NC}"
-rm -rf "$TEST_INSTALL_DIR"
+test_download_exact_version() {
+    log_test_start "Download exact version (replaces existing different version)"
 
-# Test results summary
-log "\n========================================="
-log "${YELLOW}TEST SUMMARY${NC}"
-log "========================================="
-log "Total tests: $TOTAL_TESTS"
-log "${GREEN}Passed: $PASSED_TESTS${NC}"
-log "${RED}Failed: $FAILED_TESTS${NC}"
+    local test_dir="${TEST_INSTALL_DIR}/exact_version"
+    mkdir -p "$test_dir"
 
-if [[ $FAILED_TESTS -eq 0 ]]; then
-    log "\n${GREEN}🎉 All tests passed!${NC}"
-    exit 0
-else
-    log "\n${RED}❌ Some tests failed. Check the log for details.${NC}"
-    log "Full test log: $TEST_LOG_FILE"
-    exit 1
-fi
+    # First install newer version
+    if ! "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_NEW" >> "$TEST_LOG_FILE" 2>&1; then
+        log_test_fail "Download exact version (replaces existing different version)" "First installation failed"
+        return 1
+    fi
+
+    # Install older version - should download and replace
+    if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
+        if verify_installation "$test_dir/bashate" "$VALID_VERSION_OLD" "$test_dir/.bashate-venv"; then
+            log_test_pass "Download exact version (replaces existing different version)"
+            return 0
+        else
+            log_test_fail "Download exact version (replaces existing different version)" "Version replacement verification failed"
+            return 1
+        fi
+    else
+        log_test_fail "Download exact version (replaces existing different version)" "Version replacement failed"
+        return 1
+    fi
+}
+
+# Main execution
+main() {
+    log "${YELLOW}Starting bashate download script tests...${NC}"
+
+    # Check prerequisites
+    if ! check_python; then
+        exit 1
+    fi
+
+    # Setup test environment
+    setup_test_environment
+
+    # Run tests
+    test_help_message
+    test_download_valid_version
+    test_download_invalid_version
+    test_reinstall_same_version
+    test_download_exact_version
+
+    # Cleanup
+    cleanup_test_environment
+
+    # Print summary
+    log ""
+    log "=========================================="
+    log "Test Summary:"
+    log "Total tests: $TOTAL_TESTS"
+    log "${GREEN}Passed: $PASSED_TESTS${NC}"
+    log "${RED}Failed: $FAILED_TESTS${NC}"
+    log "=========================================="
+
+    if [[ $FAILED_TESTS -eq 0 ]]; then
+        log "${GREEN}All tests passed!${NC}"
+        exit 0
+    else
+        log "${RED}Some tests failed. Check the log for details.${NC}"
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"

--- a/scripts/download/tests/test-download-operator-sdk.sh
+++ b/scripts/download/tests/test-download-operator-sdk.sh
@@ -152,7 +152,7 @@ test_old_version_when_newer_exists() {
     # Create fake newer version
     create_fake_operator_sdk_binary "$VALID_VERSION_NEW" "$test_dir/operator-sdk"
 
-    # Test should succeed without downloading (existing version meets requirement)
+    # Test should succeed and download exact version requested (replaces newer version)
     if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
         if [[ -x "$test_dir/operator-sdk" ]]; then
             log_test_pass "Request old version when newer version exists"

--- a/scripts/download/tests/test-download-opm.sh
+++ b/scripts/download/tests/test-download-opm.sh
@@ -152,7 +152,7 @@ test_old_version_when_newer_exists() {
     # Create fake newer version
     create_fake_opm_binary "$VALID_VERSION_NEW" "$test_dir/opm"
 
-    # Test should succeed without downloading (existing version meets requirement)
+    # Test should succeed and download exact version requested (replaces newer version)
     if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
         if [[ -x "$test_dir/opm" ]]; then
             log_test_pass "Request old version when newer version exists"

--- a/scripts/download/tests/test-download-yq.sh
+++ b/scripts/download/tests/test-download-yq.sh
@@ -152,7 +152,7 @@ test_old_version_when_newer_exists() {
     # Create fake newer version
     create_fake_yq_binary "$VALID_VERSION_NEW" "$test_dir/yq"
 
-    # Test should succeed without downloading (existing version meets requirement)
+    # Test should succeed and download exact version requested (replaces newer version)
     if "$DOWNLOAD_SCRIPT" --install-dir "$test_dir" "$VALID_VERSION_OLD" >> "$TEST_LOG_FILE" 2>&1; then
         if [[ -x "$test_dir/yq" ]]; then
             log_test_pass "Request old version when newer version exists"


### PR DESCRIPTION
- The scripts no longer consider any binaries in the system $PATH when downloading
- The only time the script will NOT download is if all of the following is true:
    - The binary is already in the install directory
    - The binary exactly matches the specified version
    - The binary is for the current OS and architecture
- Also updated the github workflow since we don't need to mess with the system path any more