### PR TITLE
Update rpm locking script configuration

### DIFF
--- a/scripts/rpm-lock/tests/rhel8-test/rpms.in.yaml
+++ b/scripts/rpm-lock/tests/rhel8-test/rpms.in.yaml
@@ -1,14 +1,26 @@
 contentOrigin:
   repos:
-    - repoid: ubi-8-baseos
+    - repoid: ubi-8-for-x86_64-baseos-rpms
       name: Red Hat Universal Base Image 8 (RPMs) - BaseOS
-      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os
       enabled: 1
       gpgcheck: 1
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-    - repoid: ubi-8-appstream
+    - repoid: ubi-8-for-x86_64-appstream-rpms
       name: Red Hat Universal Base Image 8 (RPMs) - AppStream
-      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os
+      enabled: 1
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+    - repoid: ubi-8-for-aarch64-baseos-rpms
+      name: Red Hat Universal Base Image 8 (RPMs) - BaseOS
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os
+      enabled: 1
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+    - repoid: ubi-8-for-aarch64-appstream-rpms
+      name: Red Hat Universal Base Image 8 (RPMs) - AppStream
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os
       enabled: 1
       gpgcheck: 1
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/scripts/rpm-lock/tests/rhel8-test/test-rhel8-integration.sh
+++ b/scripts/rpm-lock/tests/rhel8-test/test-rhel8-integration.sh
@@ -87,7 +87,7 @@ fi
 echo
 echo "Test 2: Validate input file structure"
 EXPECTED_PACKAGES=("jq" "less" "findutils" "procps-ng")
-EXPECTED_REPOS=("ubi-8-baseos" "ubi-8-appstream")
+EXPECTED_REPOS=("ubi-8-for-x86_64-baseos-rpms" "ubi-8-for-x86_64-appstream-rpms" "ubi-8-for-aarch64-baseos-rpms" "ubi-8-for-aarch64-appstream-rpms" )
 
 # Check packages
 FOUND_PACKAGES=()
@@ -176,19 +176,19 @@ if [[ "$PODMAN_AVAILABLE" == "true" ]]; then
     if [[ -f "$TEST_DIR/redhat.repo" ]]; then
         print_test_result "Generated redhat.repo file" "PASS"
 
-        # Validate repo file content based on test mode
+        # Validate that the lock file contains the expected architecture-specific repository IDs
         if [[ "$TEST_MODE" == "UBI" ]]; then
-            if grep -q "ubi-8-baseos" "$TEST_DIR/redhat.repo"; then
-                print_test_result "UBI repositories in repo file" "PASS" "Found UBI repository configurations"
+            if grep -q "ubi-8-for-.*-baseos-rpms\|ubi-8-for-.*-appstream-rpms" "$TEST_DIR/rpms.lock.yaml"; then
+                print_test_result "UBI Architecture-specific repositories in lock file" "PASS" "Found architecture-specific repository IDs in lock file"
             else
-                print_test_result "UBI repositories in repo file" "FAIL" "UBI repositories not found"
+                print_test_result "UBI Architecture-specific repositories in lock file" "FAIL" "Architecture-specific repository IDs not found in lock file"
             fi
         else
-            # RHSM mode - check for subscription-based repositories
-            if grep -q "rhel-8-for-.*-baseos-rpms\|rhel-8-for-.*-appstream-rpms" "$TEST_DIR/redhat.repo"; then
-                print_test_result "RHEL repositories in repo file" "PASS" "Found RHEL repository configurations"
+            # RHSM mode - check for subscription-based repositories in lock file
+            if grep -q "rhel-8-for-.*-baseos-rpms\|rhel-8-for-.*-appstream-rpms" "$TEST_DIR/rpms.lock.yaml"; then
+                print_test_result "RHEL Architecture-specific repositories in lock file" "PASS" "Found RHEL repository configurations in lock file"
             else
-                print_test_result "RHEL repositories in repo file" "FAIL" "RHEL repositories not found"
+                print_test_result "RHEL Architecture-specific repositories in lock file" "FAIL" "RHEL repositories not found in lock file"
             fi
         fi
     else

--- a/scripts/rpm-lock/tests/rhel9-test/rpms.in.yaml
+++ b/scripts/rpm-lock/tests/rhel9-test/rpms.in.yaml
@@ -1,14 +1,26 @@
 contentOrigin:
   repos:
-    - repoid: ubi-9-baseos
+    - repoid: ubi-9-for-x86_64-baseos-rpms
       name: Red Hat Universal Base Image 9 (RPMs) - BaseOS
-      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os
       enabled: 1
       gpgcheck: 1
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-    - repoid: ubi-9-appstream
+    - repoid: ubi-9-for-x86_64-appstream-rpms
       name: Red Hat Universal Base Image 9 (RPMs) - AppStream
-      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os
+      enabled: 1
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+    - repoid: ubi-9-for-aarch64-baseos-rpms
+      name: Red Hat Universal Base Image 9 (RPMs) - BaseOS
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os
+      enabled: 1
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+    - repoid: ubi-9-for-aarch64-appstream-rpms
+      name: Red Hat Universal Base Image 9 (RPMs) - AppStream
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os
       enabled: 1
       gpgcheck: 1
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/scripts/rpm-lock/tests/rhel9-test/test-rhel9-integration.sh
+++ b/scripts/rpm-lock/tests/rhel9-test/test-rhel9-integration.sh
@@ -86,7 +86,7 @@ fi
 echo
 echo "Test 2: Validate input file structure"
 EXPECTED_PACKAGES=("jq" "less" "findutils" "procps-ng")
-EXPECTED_REPOS=("ubi-9-baseos" "ubi-9-appstream")
+EXPECTED_REPOS=("ubi-9-for-x86_64-baseos-rpms" "ubi-9-for-x86_64-appstream-rpms" "ubi-9-for-aarch64-baseos-rpms" "ubi-9-for-aarch64-appstream-rpms")
 
 # Check packages
 FOUND_PACKAGES=()
@@ -168,19 +168,19 @@ if [[ "$PODMAN_AVAILABLE" == "true" ]]; then
     if [[ -f "$TEST_DIR/redhat.repo" ]]; then
         print_test_result "Generated redhat.repo file" "PASS"
 
-        # Validate repo file content based on test mode
+        # Validate that the lock file contains the expected architecture-specific repository IDs
         if [[ "$TEST_MODE" == "UBI" ]]; then
-            if grep -q "ubi-9-baseos" "$TEST_DIR/redhat.repo"; then
-                print_test_result "UBI repositories in repo file" "PASS" "Found UBI repository configurations"
+            if grep -q "ubi-9-for-.*-baseos-rpms\|ubi-9-for-.*-appstream-rpms" "$TEST_DIR/rpms.lock.yaml"; then
+                print_test_result "UBI Architecture-specific repositories in lock file" "PASS" "Found architecture-specific repository IDs in lock file"
             else
-                print_test_result "UBI repositories in repo file" "FAIL" "UBI repositories not found"
+                print_test_result "UBI Architecture-specific repositories in lock file" "FAIL" "Architecture-specific repository IDs not found in lock file"
             fi
         else
-            # RHSM mode - check for subscription-based repositories
-            if grep -q "rhel-9-for-.*-baseos-rpms\|rhel-9-for-.*-appstream-rpms" "$TEST_DIR/redhat.repo"; then
-                print_test_result "RHEL repositories in repo file" "PASS" "Found RHEL repository configurations"
+            # RHSM mode - check for subscription-based repositories in lock file
+            if grep -q "rhel-9-for-.*-baseos-rpms\|rhel-9-for-.*-appstream-rpms" "$TEST_DIR/rpms.lock.yaml"; then
+                print_test_result "RHEL Architecture-specific repositories in lock file" "PASS" "Found architecture-specific repository IDs in lock file"
             else
-                print_test_result "RHEL repositories in repo file" "FAIL" "RHEL repositories not found"
+                print_test_result "RHEL Architecture-specific repositories in lock file" "FAIL" "Architecture-specific repository IDs not found in lock file"
             fi
         fi
     else


### PR DESCRIPTION
- Remove unnecessary logic around disabling/enabling repositories. Since the tool uses the repos in the rpms.in.yaml file exclusively, we don't need to mess with this at all
- Update test repo names in rpms.in.yaml to use the "approved" names. See https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml for more information
- Configure both x86 and aarch64 for both RHEL8 and RHEL9 integration tests

Assisted-by: Cursor/claude-4-sonnet
AI-attribution: AIA,Human-AI blend,Reviewed,Cursor/claude-4-sonnet,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/