### PR TITLE
branch-cut: add --target-version flag for explicit version bumps

### DIFF
--- a/scripts/branch-cut/Makefile
+++ b/scripts/branch-cut/Makefile
@@ -17,12 +17,16 @@ EXCLUDE_ARG := $(if $(strip $(EXCLUDE)),--exclude $(EXCLUDE),)
 EXCLUDE_VARS ?=
 EXCLUDE_VARS_ARG := $(if $(strip $(EXCLUDE_VARS)),--exclude-vars $(EXCLUDE_VARS),)
 
+# Target version (optional): set to override the default MINOR+1 bump (e.g., 5.0 for a major bump)
+TARGET_VERSION ?=
+TARGET_VERSION_ARG := $(if $(strip $(TARGET_VERSION)),--target-version $(TARGET_VERSION),)
+
 # Check for uncommitted changes before switching branches (default: true)
 CHECK_UNCOMMITTED ?= true
 
-# Compute new version from CURRENT_VERSION (X.Y.Z -> X.(Y+1))
+# Compute new version from CURRENT_VERSION and optional TARGET_VERSION
 define compute_new_version
-$(shell echo "$(CURRENT_VERSION)" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1.\2/' | awk -F. '{print $$1"."($$2+1)}')
+$(if $(strip $(TARGET_VERSION)),$(shell echo "$(TARGET_VERSION)" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1.\2/'),$(shell echo "$(CURRENT_VERSION)" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1.\2/' | awk -F. '{print $$1"."($$2+1)}'))
 endef
 
 # Compute release branch name from CURRENT_VERSION (X.Y.Z -> release-X.Y)
@@ -43,7 +47,7 @@ branch-cut: ## Perform full branch cut (bump on main + prepare release branch)
 	@echo "Branch cut: $(CURRENT_VERSION) -> $(NEW_VERSION)"
 	@echo "Release branch: $(RELEASE_BRANCH)"
 	@echo ""
-	$(SCRIPT_DIR)/konflux-branch-cut.sh --current-version "$(CURRENT_VERSION)" --project-root "$(PROJECT_ROOT)" $(EXCLUDE_ARG) $(EXCLUDE_VARS_ARG)
+	$(SCRIPT_DIR)/konflux-branch-cut.sh --current-version "$(CURRENT_VERSION)" --project-root "$(PROJECT_ROOT)" $(TARGET_VERSION_ARG) $(EXCLUDE_ARG) $(EXCLUDE_VARS_ARG)
 
 # Example:
 #   make branch-cut-with-git CURRENT_VERSION=4.21.0
@@ -77,7 +81,7 @@ branch-cut-with-git: ## Perform full branch cut with git workflow (fetch, branch
 	@git -C "$(PROJECT_ROOT)" checkout -b "$(BRANCH_NAME)"
 	@echo ""
 	@echo "==> Performing branch cut..."
-	$(SCRIPT_DIR)/konflux-branch-cut.sh --current-version "$(CURRENT_VERSION)" --project-root "$(PROJECT_ROOT)" $(EXCLUDE_ARG) $(EXCLUDE_VARS_ARG)
+	$(SCRIPT_DIR)/konflux-branch-cut.sh --current-version "$(CURRENT_VERSION)" --project-root "$(PROJECT_ROOT)" $(TARGET_VERSION_ARG) $(EXCLUDE_ARG) $(EXCLUDE_VARS_ARG)
 	@echo ""
 	@echo "==> Staging and committing changes on current branch..."
 	@git -C "$(PROJECT_ROOT)" add -A
@@ -113,6 +117,7 @@ help: ## Display available targets
 	@echo ""
 	@echo "Variables:"
 	@echo "  CURRENT_VERSION     Current version to branch cut from (e.g., 4.21.0)"
+	@echo "  TARGET_VERSION      Target version to bump to (optional, default: MINOR+1)"
 	@echo "  PROJECT_ROOT        Project root directory (default: repo root)"
 	@echo "  EXCLUDE             Comma/space-separated: paths or extensions (use .ext, e.g., .gz)"
 	@echo "  EXCLUDE_VARS        Comma/space-separated: variable names to skip in replacements (e.g., RUNTIME_IMAGE,OPM_IMAGE)"
@@ -121,6 +126,7 @@ help: ## Display available targets
 	@echo "Examples:"
 	@echo "  make branch-cut CURRENT_VERSION=4.21.0"
 	@echo "  make branch-cut-with-git CURRENT_VERSION=4.21.0"
+	@echo "  make branch-cut CURRENT_VERSION=4.22.0 TARGET_VERSION=5.0.0"
 	@echo "  make branch-cut CURRENT_VERSION=4.21.0 EXCLUDE=\"docs/,.png\""
 	@echo "  make branch-cut CURRENT_VERSION=4.21.0 EXCLUDE_VARS=\"RUNTIME_IMAGE,OPM_IMAGE\""
 	@echo ""

--- a/scripts/branch-cut/README.md
+++ b/scripts/branch-cut/README.md
@@ -9,7 +9,7 @@ Branch cut is the process of preparing a new project version. It automatically u
 The script automates two main tasks:
 
 ### 1. Version update on `main`
-- Increments the version number (example: 4.21 → 4.22)
+- Increments the version number (example: 4.21 → 4.22), or bumps to a specific target version (example: 4.22 → 5.0)
 - Updates all version references in the code
 - Renames Tekton pipeline files with the new version
 
@@ -44,6 +44,18 @@ This command will create two branches:
 - `branch-cut-to-4.22` → for PR to `main`
 - `prepare-release-4.21` → for PR to `release-4.21`
 
+### Specifying a target version
+
+By default the script increments the minor version by 1. To bump to a specific version (e.g., a major version change), use `TARGET_VERSION`:
+
+```bash
+make branch-cut-with-git CURRENT_VERSION=4.22.0 TARGET_VERSION=5.0.0
+```
+
+This will create:
+- `branch-cut-to-5.0` → for PR to `main` (replaces 4.22 references with 5.0)
+- `prepare-release-4.22` → for PR to `release-4.22`
+
 ## Complete steps
 
 ### Option 1: With automatic git workflow (recommended)
@@ -51,6 +63,9 @@ This command will create two branches:
 ```bash
 # 1. Execute branch cut (creates local branches and commits)
 make branch-cut-with-git CURRENT_VERSION=4.21.0
+
+# Or with a specific target version:
+# make branch-cut-with-git CURRENT_VERSION=4.22.0 TARGET_VERSION=5.0.0
 
 # 2. Verify changes (script never pushes, review first!)
 git log
@@ -81,6 +96,7 @@ git diff
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `CURRENT_VERSION` | **Required**. Current version | `4.21.0` |
+| `TARGET_VERSION` | Target version to bump to (default: MINOR+1) | `5.0.0` |
 | `EXCLUDE` | Exclude files/directories/extensions | `"docs/,.png,.gz"` |
 | `EXCLUDE_VARS` | Exclude variable assignments from version replacement | `"RUNTIME_IMAGE,OPM_IMAGE"` |
 | `CHECK_UNCOMMITTED` | Check for uncommitted changes | `false` |
@@ -104,6 +120,21 @@ The result will be:
 VERSION=4.22.0
 RUNTIME_IMAGE=registry.io/base:4.21   # <- Not changed
 OPM_IMAGE=registry.io/opm:4.21         # <- Not changed
+```
+
+### Example with target version
+
+```bash
+# Major version bump: 4.22 -> 5.0
+make branch-cut-with-git CURRENT_VERSION=4.22.0 TARGET_VERSION=5.0.0
+
+# Non-sequential minor bump: 4.21 -> 4.25
+make branch-cut-with-git CURRENT_VERSION=4.21.0 TARGET_VERSION=4.25.0
+
+# Combine with exclusions
+make branch-cut-with-git CURRENT_VERSION=4.22.0 TARGET_VERSION=5.0.0 \
+  EXCLUDE="docs/,.png" \
+  EXCLUDE_VARS="RUNTIME_IMAGE,OPM_IMAGE"
 ```
 
 ### Example with exclusions

--- a/scripts/branch-cut/konflux-branch-cut.sh
+++ b/scripts/branch-cut/konflux-branch-cut.sh
@@ -8,10 +8,13 @@ cat << EOF
 NAME
     $SCRIPT_NAME - perform branch cut operations for a new release
 SYNOPSIS
-    $SCRIPT_NAME --current-version VERSION [--project-root DIR] [--exclude LIST]
+    $SCRIPT_NAME --current-version VERSION [--target-version VERSION] [--project-root DIR] [--exclude LIST]
 EXAMPLES
-    - Perform full branch cut from 4.21.0:
+    - Perform full branch cut from 4.21.0 (auto-increments to 4.22.0):
             $ $SCRIPT_NAME --current-version 4.21.0
+
+    - Perform branch cut with explicit target version (e.g., major bump):
+            $ $SCRIPT_NAME --current-version 4.22.0 --target-version 5.0.0
 DESCRIPTION
     This script performs the complete branch cut workflow:
     1. On main branch - Version bump:
@@ -25,6 +28,10 @@ DESCRIPTION
 ARGS
     --current-version VERSION
         Current version (e.g., 4.21.0 or 4.21). Patch is normalized to .0 when computing the new version.
+    --target-version VERSION
+        Target version to bump to (e.g., 5.0.0 or 5.0). If omitted, the minor version is incremented
+        by 1 (MAJOR.MINOR -> MAJOR.(MINOR+1)). Use this to perform non-sequential bumps such as
+        major version changes (4.22 -> 5.0).
     --project-root DIR
         Project root directory. Defaults to the current git repository root or current working directory if not a git repo.
   --exclude LIST | --exclude PATH
@@ -46,6 +53,7 @@ parse_args() {
             exit 1
     fi
     CURRENT_VERSION=""
+    TARGET_VERSION=""
     PROJECT_ROOT=""
     EXCLUDES=()
     EXCLUDE_EXTS=()
@@ -62,6 +70,14 @@ parse_args() {
                 exit 1
             fi
             CURRENT_VERSION="$2"
+            shift 2
+            ;;
+        --target-version)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --target-version requires a value" >&2
+                exit 1
+            fi
+            TARGET_VERSION="$2"
             shift 2
             ;;
         --project-root)
@@ -145,16 +161,37 @@ normalize_and_compute_versions() {
     fi
     MAJOR="${BASH_REMATCH[1]}"
     MINOR="${BASH_REMATCH[2]}"
-    # Compute new minor
-    NEW_MINOR=$((10#$MINOR + 1))
+
+    local new_major new_minor
+    if [[ -n "$TARGET_VERSION" ]]; then
+            # Use explicitly provided target version
+            if [[ ! "$TARGET_VERSION" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))?$ ]]; then
+                echo "Error: invalid target version format '$TARGET_VERSION' (expected MAJOR.MINOR or MAJOR.MINOR.PATCH)" >&2
+                exit 1
+            fi
+            new_major="${BASH_REMATCH[1]}"
+            new_minor="${BASH_REMATCH[2]}"
+            # Validate target is different from current
+            if [[ "$new_major" -eq "$MAJOR" && "$new_minor" -eq "$MINOR" ]]; then
+                echo "Error: target version '$TARGET_VERSION' is the same as current version '$ver'" >&2
+                exit 1
+            fi
+    else
+            # Default: increment minor by 1
+            new_major="$MAJOR"
+            new_minor=$((10#$MINOR + 1))
+    fi
+
+    NEW_MAJOR="$new_major"
+    NEW_MINOR="$new_minor"
     # Old variants (what to search)
     OLD_DOT="${MAJOR}.${MINOR}"
     OLD_FULL="${MAJOR}.${MINOR}.0"
     OLD_DASH="${MAJOR}-${MINOR}"
     # New variants (what to replace with)
-    NEW_DOT="${MAJOR}.${NEW_MINOR}"
-    NEW_FULL="${MAJOR}.${NEW_MINOR}.0"
-    NEW_DASH="${MAJOR}-${NEW_MINOR}"
+    NEW_DOT="${NEW_MAJOR}.${NEW_MINOR}"
+    NEW_FULL="${NEW_MAJOR}.${NEW_MINOR}.0"
+    NEW_DASH="${NEW_MAJOR}-${NEW_MINOR}"
     # Compute release branch name (release-X.Y)
     RELEASE_BRANCH="release-${MAJOR}.${MINOR}"
 }
@@ -336,7 +373,7 @@ rename_tekton_pipelines() {
             if [[ "$filename" =~ -${MAJOR}-${MINOR}- ]]; then
         # Replace old version with new version in filename
         local new_filename
-        new_filename="${filename//-${MAJOR}-${MINOR}-/-${MAJOR}-${NEW_MINOR}-}"
+        new_filename="${filename//-${MAJOR}-${MINOR}-/-${NEW_MAJOR}-${NEW_MINOR}-}"
         if [[ "$filename" != "$new_filename" ]]; then
             local old_path="$dirname_part/$filename"
             local new_path="$dirname_part/$new_filename"


### PR DESCRIPTION
The branch cut script previously only supported incrementing the minor version by 1 (e.g., 4.21 -> 4.22). This makes it impossible to perform major version bumps (e.g., 4.22 -> 5.0) or non-sequential jumps.

Add an optional --target-version flag to the script and a TARGET_VERSION variable to the Makefile so users can specify the exact version to bump to. When omitted, the default MINOR+1 behavior is preserved.

Made-with: Cursor