### PR TITLE
CNF-24389: Fix tool installs when cross compile flags are set

### DIFF
--- a/scripts/download/download-go-tool.sh
+++ b/scripts/download/download-go-tool.sh
@@ -271,9 +271,11 @@ main() {
             exit 1
         fi
 
-        # Install the tool with GOBIN pointing to our install directory
+        # Install the tool with GOBIN pointing to our install directory.
+        # Unset GOARCH/GOOS so go install doesn't treat this as a cross-compilation
+        # (go refuses to install cross-compiled binaries when GOBIN is set).
         echo "Downloading ${go_module}..."
-        if ! GOBIN="${install_dir}" go install "${go_module}"; then
+        if ! GOBIN="${install_dir}" GOARCH="" GOOS="" go install "${go_module}"; then
             echo "ERROR: Failed to install ${go_module}"
             echo "Please check that the module path and version are correct"
             exit 1


### PR DESCRIPTION
- The tools are not architecture specific, but go will fail to install them if the flags are set at the same time as GOBIN
- Since we prefer to install in the GOBIN directly, null the conflicting flags for the install only

Assisted-by: ClaudeCode/sonnet-4.6
AI-attribution: AIA,Human-AI blend,Human-initiated,Reviewed,ClaudeCode/sonnet-4.6,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/