### PR TITLE
Add networking.k8s.io/networkpolicies RBAC to TALM overlay test data

### DIFF
--- a/test/overlay/talm/4.20/00.data/cluster-group-upgrades-operator.clusterserviceversion.in.yaml
+++ b/test/overlay/talm/4.20/00.data/cluster-group-upgrades-operator.clusterserviceversion.in.yaml
@@ -383,6 +383,12 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - '*'
+            - apiGroups:
                 - policy.open-cluster-management.io
               resources:
                 - placementbindings

--- a/test/overlay/talm/4.20/00.data/expected/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/test/overlay/talm/4.20/00.data/expected/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -386,6 +386,12 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - '*'
+            - apiGroups:
                 - policy.open-cluster-management.io
               resources:
                 - placementbindings


### PR DESCRIPTION
## Summary
- Add `networking.k8s.io/networkpolicies` RBAC entry with wildcard verbs to the TALM 4.20 overlay CSV test input and expected output

## Context
Companion PR to [openshift-kni/cluster-group-upgrades-operator#9977](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/9977) which adds NetworkPolicy RBAC permissions to the TALM operator CSV to comply with the Konflux Conforma policy `olm.required_network_policy_rbac_for_operands` ([KONFLUX-13290](https://redhat.atlassian.net/browse/KONFLUX-13290)).

The overlay test data needs to be updated to include the new RBAC entry so that tests pass after the upstream change is merged.

## Test plan
- [ ] Overlay test passes with the new entry matching the upstream CSV

Made with [Cursor](https://cursor.com)